### PR TITLE
Fix Issue #14 -- Output Files Mixup

### DIFF
--- a/src/ThrainIO.cpp
+++ b/src/ThrainIO.cpp
@@ -510,7 +510,7 @@ int write_stellar_output(Calculation::OutputData& calcdata){
 	int d=0;
 	printf("Writing stellar data to file...\t");fflush(stdout);
 	//open file to write output summary
-	std::string output_file_name = "./output/"+calcdata.calcname+"/"+calcdata.calcname+"_in.txt";
+	std::string output_file_name = "./output/"+calcdata.calcname+"/"+calcdata.calcname+".txt";
 	FILE* output_file;
 	//try to open the output file
 	if( !(output_file = fopen(output_file_name.c_str(), "w")) ){

--- a/src/ThrainIO.cpp
+++ b/src/ThrainIO.cpp
@@ -389,7 +389,12 @@ int echo_input(Calculation::InputData &calcdata){
 			fprintf(output_file, "cowling\t");
 			break;	
 	}
-	fprintf(output_file, "%1.3lf\n", calcdata.adiabatic_index);
+	// write the adiabatic index
+	double a = calcdata.adiabatic_index*3.0;
+	if(fabs(a-5.0)<1e-10) fprintf(output_file, "5/3\n");
+	else if (fabs(a-4.0)<1e-10) fprintf(output_file, "4/3\n");
+	else fprintf(output_file, "%1.3lf\n", calcdata.adiabatic_index);
+	// write the requested mode numbers
 	int checkcount=0;
 	for(int L : calcdata.l){
 		for(int K : calcdata.kl.at(L)){
@@ -401,9 +406,6 @@ int echo_input(Calculation::InputData &calcdata){
 		printf("non-matching numbers of modes");
 		return 1;
 	}
-	// for(int j=0; j<calcdata.mode_num; j++){
-	// 	fprintf(output_file, "%d,%d\n", calcdata.l[j], calcdata.k[j]);
-	// }
 	
 	printf("done\n");
 	fflush(output_file);

--- a/src/ThrainIO.cpp
+++ b/src/ThrainIO.cpp
@@ -602,7 +602,7 @@ int write_stellar_output(Calculation::OutputData& calcdata){
 	if(calcdata.teff!=0.0)
 	fprintf(output_file,"%s      Teff (K)%s= %lg %s",    dwarf[d++], unitZ.c_str(), calcdata.teff,  (calcdata.params&units::ParamType::pteff?"(specified)\n":"(derived)\n"));
 	else
-	fprintf(output_file,"%s      Teff      = N/A \n",    dwarf[d++]);	
+	fprintf(output_file,"%s      Teff    %s= N/A \n",    dwarf[d++], unitZ.c_str());	
 	fprintf(output_file,"%s      log g%s   = %1.5lg %s", dwarf[d++], unitG.c_str(), calcdata.logg,  (calcdata.params&units::ParamType::plogg?"(specified)\n":"(derived)\n"));
 	fprintf(output_file,"%s      Zsurf  %s = %1.5le %s", dwarf[d++], unitZ.c_str(), calcdata.zsurf, (calcdata.params&units::ParamType::pzsurf?"(specified)\n":"(derived)\n"));
 	fprintf(output_file,"%s  \n", dwarf[d++]);

--- a/src/ThrainUnits.h
+++ b/src/ThrainUnits.h
@@ -44,9 +44,7 @@ const std::unordered_map<Units, UnitSet> unitSets = {
 	{Units::geo, {1.0, 1.0, 1.0/C_CGS, 1.0, C_CGS/G_CGS}},
 	// standard international units
 	{Units::SI, {G_CGS*1.0e-3, C_CGS*1.0e-2, 100, 1.0, 1000.0}},
-	{Units::CGS, {G_CGS, C_CGS, 1.0, 1.0, 1.0}},
-	// the default, erroneous case
-	{Units(-85), {0.0, 0.0, 0.0, 0.0, 0.0}}
+	{Units::CGS, {G_CGS, C_CGS, 1.0, 1.0, 1.0}}
 };
 
 //format units in the chosen unit system

--- a/src/ThrainUnits.h
+++ b/src/ThrainUnits.h
@@ -44,7 +44,9 @@ const std::unordered_map<Units, UnitSet> unitSets = {
 	{Units::geo, {1.0, 1.0, 1.0/C_CGS, 1.0, C_CGS/G_CGS}},
 	// standard international units
 	{Units::SI, {G_CGS*1.0e-3, C_CGS*1.0e-2, 100, 1.0, 1000.0}},
-	{Units::CGS, {G_CGS, C_CGS, 1.0, 1.0, 1.0}}
+	{Units::CGS, {G_CGS, C_CGS, 1.0, 1.0, 1.0}},
+	// the default, erroneous case
+	{Units(-85), {0.0, 0.0, 0.0, 0.0, 0.0}}
 };
 
 //format units in the chosen unit system

--- a/tests/thrainunits_test.h
+++ b/tests/thrainunits_test.h
@@ -106,12 +106,12 @@ public:
         TS_ASSERT(fakeData.freq0 == sqrt(G_CGS*mcgs*pow(rcgs,-3)));
     }
 
-    void test_setAllUnits_noparams(){
-        do_test_setUnits_noparams(units::Units::astro);
-        do_test_setUnits_noparams(units::Units::geo);
-        do_test_setUnits_noparams(units::Units::SI);
-        do_test_setUnits_noparams(units::Units::CGS);
-    }
+    // void test_setAllUnits_noparams(){
+    //     do_test_setUnits_noparams(units::Units::astro);
+    //     do_test_setUnits_noparams(units::Units::geo);
+    //     do_test_setUnits_noparams(units::Units::SI);
+    //     do_test_setUnits_noparams(units::Units::CGS);
+    // }
 
     void test_setAllUnits(){
         do_test_setUnits(units::Units::astro);

--- a/tests/thrainunits_test.h
+++ b/tests/thrainunits_test.h
@@ -63,13 +63,9 @@ public:
         fakeData1.driver = nullptr;
         fakeData1.i_err = 0;
         fakeData1.units = units::Units::astro;
+        fprintf(stderr, "BEFORE\n");
         TS_ASSERT_THROWS_NOTHING(units::format_units(fakeData1));
-        // assert units safely zeroed out
-        // TS_ASSERT(fakeData1.unitset.G == 0.0);
-        // TS_ASSERT(fakeData1.unitset.C == 0.0);
-        // TS_ASSERT(fakeData1.unitset.base_length == 0.0);
-        // TS_ASSERT(fakeData1.unitset.base_time == 0.0);
-        // TS_ASSERT(fakeData1.unitset.base_mass == 0.0);
+        fprintf(stderr, "AFTER\n");
         // assert all safely zeroed out
         TS_ASSERT(fakeData1.mass == 0.0);
         TS_ASSERT(fakeData1.radius == 0.0);

--- a/tests/thrainunits_test.h
+++ b/tests/thrainunits_test.h
@@ -63,6 +63,12 @@ public:
         fakeData1.driver = nullptr;
         fakeData1.i_err = 0;
         TS_ASSERT_THROWS_NOTHING(units::format_units(fakeData1));
+        // assert units safely zeroed out
+        TS_ASSERT(fakeData1.unitset.G == 0.0);
+        TS_ASSERT(fakeData1.unitset.C == 0.0);
+        TS_ASSERT(fakeData1.unitset.base_length == 0.0);
+        TS_ASSERT(fakeData1.unitset.base_time == 0.0);
+        TS_ASSERT(fakeData1.unitset.base_mass == 0.0);
         // assert all safely zeroed out
         TS_ASSERT(fakeData1.mass == 0.0);
         TS_ASSERT(fakeData1.radius == 0.0);
@@ -100,6 +106,13 @@ public:
         TS_ASSERT_DELTA(fakeData.zsurf, zsurf, 1e-4);
         TS_ASSERT(fakeData.logg == logg);
         TS_ASSERT(fakeData.freq0 == sqrt(G_CGS*mcgs*pow(rcgs,-3)));
+    }
+
+    void test_setAllUnits_noparams(){
+        do_test_setUnits_noparams(units::Units::astro);
+        do_test_setUnits_noparams(units::Units::geo);
+        do_test_setUnits_noparams(units::Units::SI);
+        do_test_setUnits_noparams(units::Units::CGS);
     }
 
     void test_setAllUnits(){

--- a/tests/thrainunits_test.h
+++ b/tests/thrainunits_test.h
@@ -13,13 +13,13 @@ public:
         delete suite; 
     }
 
-    void setUp() {
-        freopen("tests/artifacts/logio.txt", "a", stdout);
-    }
+    // void setUp() {
+    //     freopen("tests/artifacts/logio.txt", "a", stdout);
+    // }
 
-    void tearDown() {
-        freopen("/dev/tty", "w", stdout);
-    }
+    // void tearDown() {
+    //     freopen("/dev/tty", "w", stdout);
+    // }
 
     Calculation::OutputData setupFakeCalcData(units::Units unitType){
         Calculation::OutputData fakeData;

--- a/tests/thrainunits_test.h
+++ b/tests/thrainunits_test.h
@@ -63,9 +63,7 @@ public:
         fakeData1.driver = nullptr;
         fakeData1.i_err = 0;
         fakeData1.units = units::Units::astro;
-        fprintf(stderr, "BEFORE\n");
         TS_ASSERT_THROWS_NOTHING(units::format_units(fakeData1));
-        fprintf(stderr, "AFTER\n");
         // assert all safely zeroed out
         TS_ASSERT(fakeData1.mass == 0.0);
         TS_ASSERT(fakeData1.radius == 0.0);
@@ -78,7 +76,7 @@ public:
         fakeData2.driver = nullptr;
         fakeData2.i_err = 0;
         fakeData2.params = 0;
-        fakeData1.units = units::Units::astro;
+        fakeData2.units = units::Units::astro;
         TS_ASSERT_THROWS_NOTHING(units::format_units(fakeData2));
         // assert all safely zeroed out
         TS_ASSERT(fakeData2.mass == 0.0);
@@ -106,12 +104,12 @@ public:
         TS_ASSERT(fakeData.freq0 == sqrt(G_CGS*mcgs*pow(rcgs,-3)));
     }
 
-    // void test_setAllUnits_noparams(){
-    //     do_test_setUnits_noparams(units::Units::astro);
-    //     do_test_setUnits_noparams(units::Units::geo);
-    //     do_test_setUnits_noparams(units::Units::SI);
-    //     do_test_setUnits_noparams(units::Units::CGS);
-    // }
+    void test_setAllUnits_noparams(){
+        do_test_setUnits_noparams(units::Units::astro);
+        do_test_setUnits_noparams(units::Units::geo);
+        do_test_setUnits_noparams(units::Units::SI);
+        do_test_setUnits_noparams(units::Units::CGS);
+    }
 
     void test_setAllUnits(){
         do_test_setUnits(units::Units::astro);

--- a/tests/thrainunits_test.h
+++ b/tests/thrainunits_test.h
@@ -62,6 +62,7 @@ public:
         fakeData1.star = nullptr;
         fakeData1.driver = nullptr;
         fakeData1.i_err = 0;
+        fakeData1.units = units::Units(-85);
         TS_ASSERT_THROWS_NOTHING(units::format_units(fakeData1));
         // assert units safely zeroed out
         TS_ASSERT(fakeData1.unitset.G == 0.0);
@@ -81,6 +82,7 @@ public:
         fakeData2.driver = nullptr;
         fakeData2.i_err = 0;
         fakeData2.params = 0;
+        fakeData1.units = units::Units::astro;
         TS_ASSERT_THROWS_NOTHING(units::format_units(fakeData2));
         // assert all safely zeroed out
         TS_ASSERT(fakeData2.mass == 0.0);

--- a/tests/thrainunits_test.h
+++ b/tests/thrainunits_test.h
@@ -62,7 +62,7 @@ public:
         fakeData1.star = nullptr;
         fakeData1.driver = nullptr;
         fakeData1.i_err = 0;
-        fakeData1.units = units::Unit::astro;
+        fakeData1.units = units::Units::astro;
         TS_ASSERT_THROWS_NOTHING(units::format_units(fakeData1));
         // assert units safely zeroed out
         // TS_ASSERT(fakeData1.unitset.G == 0.0);

--- a/tests/thrainunits_test.h
+++ b/tests/thrainunits_test.h
@@ -13,13 +13,13 @@ public:
         delete suite; 
     }
 
-    // void setUp() {
-    //     freopen("tests/artifacts/logio.txt", "a", stdout);
-    // }
+    void setUp() {
+        freopen("tests/artifacts/logio.txt", "a", stdout);
+    }
 
-    // void tearDown() {
-    //     freopen("/dev/tty", "w", stdout);
-    // }
+    void tearDown() {
+        freopen("/dev/tty", "w", stdout);
+    }
 
     Calculation::OutputData setupFakeCalcData(units::Units unitType){
         Calculation::OutputData fakeData;
@@ -62,13 +62,13 @@ public:
         fakeData1.star = nullptr;
         fakeData1.driver = nullptr;
         fakeData1.i_err = 0;
-        fakeData1.units = units::Units::astro;
+        fakeData1.units = unitType;
         TS_ASSERT_THROWS_NOTHING(units::format_units(fakeData1));
         // assert all safely zeroed out
-        TS_ASSERT(fakeData1.mass == 0.0);
-        TS_ASSERT(fakeData1.radius == 0.0);
-        TS_ASSERT(fakeData1.zsurf == 0.0);
-        TS_ASSERT(fakeData1.logg == 0.0);
+        TS_ASSERT_EQUALS(fakeData1.mass, 0.0);
+        TS_ASSERT_EQUALS(fakeData1.radius, 0.0);
+        TS_ASSERT_EQUALS(fakeData1.zsurf, 0.0);
+        TS_ASSERT_EQUALS(fakeData1.logg, 0.0);
 
         // test with a zero-set params
         Calculation::OutputData fakeData2;
@@ -76,13 +76,13 @@ public:
         fakeData2.driver = nullptr;
         fakeData2.i_err = 0;
         fakeData2.params = 0;
-        fakeData2.units = units::Units::astro;
+        fakeData2.units = unitType;
         TS_ASSERT_THROWS_NOTHING(units::format_units(fakeData2));
         // assert all safely zeroed out
-        TS_ASSERT(fakeData2.mass == 0.0);
-        TS_ASSERT(fakeData2.radius == 0.0);
-        TS_ASSERT(fakeData2.zsurf == 0.0);
-        TS_ASSERT(fakeData2.logg == 0.0);
+        TS_ASSERT_EQUALS(fakeData2.mass, 0.0);
+        TS_ASSERT_EQUALS(fakeData2.radius, 0.0);
+        TS_ASSERT_EQUALS(fakeData2.zsurf, 0.0);
+        TS_ASSERT_EQUALS(fakeData2.logg, 0.0);
     }    
 
     void do_test_setUnits(units::Units unitType){

--- a/tests/thrainunits_test.h
+++ b/tests/thrainunits_test.h
@@ -62,14 +62,14 @@ public:
         fakeData1.star = nullptr;
         fakeData1.driver = nullptr;
         fakeData1.i_err = 0;
-        fakeData1.units = units::Units(-85);
+        fakeData1.units = units::Unit::astro;
         TS_ASSERT_THROWS_NOTHING(units::format_units(fakeData1));
         // assert units safely zeroed out
-        TS_ASSERT(fakeData1.unitset.G == 0.0);
-        TS_ASSERT(fakeData1.unitset.C == 0.0);
-        TS_ASSERT(fakeData1.unitset.base_length == 0.0);
-        TS_ASSERT(fakeData1.unitset.base_time == 0.0);
-        TS_ASSERT(fakeData1.unitset.base_mass == 0.0);
+        // TS_ASSERT(fakeData1.unitset.G == 0.0);
+        // TS_ASSERT(fakeData1.unitset.C == 0.0);
+        // TS_ASSERT(fakeData1.unitset.base_length == 0.0);
+        // TS_ASSERT(fakeData1.unitset.base_time == 0.0);
+        // TS_ASSERT(fakeData1.unitset.base_mass == 0.0);
         // assert all safely zeroed out
         TS_ASSERT(fakeData1.mass == 0.0);
         TS_ASSERT(fakeData1.radius == 0.0);


### PR DESCRIPTION
This fixes Issue #14 

Go to main, build, run any input file.
- View the `calcname_in.txt` file.  It will be (errantly) the stellar data splash.  The echo of the input file is absent.
- View the `calcname.txt` file.  It will (errantly) have only the pulsation results.

Now go to this branch, build, run same inout file.  
- View the `calcname_in.txt` file.  It will have an echo of the input file.
- View the `calcname.txt` file.  It will have both the stellar data splash and the pulsation results.