### PR TITLE
Create a simple logger for output

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -93,6 +93,16 @@ jobs:
             archiver: "7z a",
             generators: "Ninja"
           }
+          - {
+            name: "windows msvc",
+            os: windows-latest,
+            artifact: "windows_mingw.7z",
+            build_type: "Release",
+            cc: "cl",
+            cxx: "cl",
+            archiver: "7z a",
+            generators: "Ninja"
+          }
 
         # TODO setup windows runners
 
@@ -133,7 +143,12 @@ jobs:
         run: |
           brew install cxxtest 
           sed 's/CC=g++/CC=${{ matrix.config.cxx }}/' makefile > changed.txt && mv changed.txt makefile
-    
+
+      - name: Install dependencies on windows
+        if: ${{ matrix.config.cc == 'cl' }}
+        # need to configure MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Build library
         shell: bash
         run: make library

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -93,18 +93,16 @@ jobs:
             archiver: "7z a",
             generators: "Ninja"
           }
-          - {
-            name: "windows msvc",
-            os: windows-latest,
-            artifact: "windows_mingw.7z",
-            build_type: "Release",
-            cc: "cl",
-            cxx: "cl",
-            archiver: "7z a",
-            generators: "Ninja"
-          }
-
-        # TODO setup windows runners
+        - {
+          name: "windows msvc",
+          os: windows-latest,
+          artifact: "windows_mingw.7z",
+          build_type: "Release",
+          cc: "cl",
+          cxx: "cl",
+          archiver: "7z a",
+          generators: "Ninja"
+        }
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ src/STARS/ZAMS.cpp
 !lib/Splinor.*
 !lib/stellar.*
 !lib/string.*
+!lib/logger.h
 lib/*.o
 
 # the test suite

--- a/lib/logger.h
+++ b/lib/logger.h
@@ -1,0 +1,158 @@
+#ifndef THRAINLOGGER
+#define THRAINLOGGER
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <mutex>
+#include <ctime>
+#include <cstdarg>
+#include "string.h"
+
+class ThrainLogger {
+
+public:
+  enum class LogLevel : unsigned char { DEBUG = 0, INFO, WARNING, ERROR, MUTE = 0xFF };
+
+private:
+  bool logToFile;
+  FILE *fp;
+  std::mutex logMutex;
+  LogLevel logLevel;
+
+  // singleton
+  static ThrainLogger& instance() {
+    static ThrainLogger logger;
+    return logger;
+  }
+
+  // private constructor, defaults to INFO level to stdout
+  ThrainLogger() : logToFile(false), fp(stdout), logLevel(LogLevel::INFO) {}
+
+public:
+  // delete copy and move operations
+  ThrainLogger(ThrainLogger const&) = delete;
+  ThrainLogger& operator=(ThrainLogger const&) = delete;
+  ThrainLogger(ThrainLogger&&) = delete;
+  ThrainLogger& operator=(ThrainLogger&&) = delete;
+
+  // deconstructor
+  ~ThrainLogger() {
+    closeOpenLogFile();
+  }
+
+  static void setOutputFile(std::string const& filename, char const *access = "a") {
+    // check if the file exists
+    FILE *otherfp = fopen(filename.c_str(), access);
+    if (!otherfp) {
+      fprintf(stderr, "Failed to open log file %s; logger output file not changed\n", filename.c_str());
+    } else {
+      // close any open log file
+      instance().closeOpenLogFile();
+      // set the file
+      instance().fp = otherfp;
+      instance().logToFile = true;
+    }
+  }
+
+  static void unsetOutputFile() {
+    instance().closeOpenLogFile();
+    instance().fp = stdout;
+  }
+
+  static void setLogLevel(LogLevel level) {
+    instance().logLevel = level;
+  }
+
+  static void debug(char const *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    instance().innerlog(LogLevel::DEBUG, fmt, args);
+    va_end(args);
+  }
+
+  static void info(char const *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    instance().innerlog(LogLevel::INFO, fmt, args);
+    va_end(args);
+  }
+
+  static void warning(char const *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    instance().innerlog(LogLevel::WARNING, fmt, args);
+    va_end(args);
+  }
+
+  static void error(char const *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    instance().innerlog(LogLevel::ERROR, fmt, args);
+    va_end(args);
+  }
+
+  static void log(LogLevel level, char const *fmt, ...) {
+    if(level != LogLevel::MUTE) {
+      va_list args;
+      va_start(args, fmt);
+      instance().innerlog(level, fmt, args);
+      va_end(args);
+    }
+  }
+
+  static void logInline(LogLevel level, char const *fmt, ...) {
+    if (level != LogLevel::MUTE && level >= instance().logLevel) {
+      std::lock_guard<std::mutex> lock(instance().logMutex);
+      va_list args;
+      va_start(args, fmt);
+      vfprintf(instance().fp, fmt, args);
+      va_end(args);
+      fflush(instance().fp);
+    }
+  }
+
+private:
+
+  void closeOpenLogFile() {
+    if (logToFile && fp) {
+      std::lock_guard<std::mutex> lock(logMutex);
+      fclose(fp);
+      logToFile = false;
+    }
+  }
+
+  void innerlog(LogLevel level, char const *fmt, va_list args) {
+    if (level >= logLevel ) {
+      std::lock_guard<std::mutex> lock(logMutex);
+      std::string log_fmt = strmakef("%s [%s]: %s", currentDateTime().c_str(), levelToString(level).c_str(), fmt);
+      vfprintf(fp, log_fmt.c_str(), args);
+      fflush(fp);
+    }
+  }
+
+  std::string levelToString(LogLevel level) {
+    switch (level) {
+      case LogLevel::DEBUG:   return "DEBUG";
+      case LogLevel::INFO:    return "INFO";
+      case LogLevel::WARNING: return "WARNING";
+      case LogLevel::ERROR:   return "ERROR";
+      default:                return "UNKNOWN";
+    }
+  }
+
+  std::string currentDateTime() {
+    std::time_t now = std::time(nullptr);
+    std::tm tm_info;
+#if defined(_MSC_VER)
+    localtime_s(&tm_info, &now);
+#else
+    localtime_r(&now, &tm_info);
+#endif
+    char buf[20] = {0};
+    strftime(buf, 20, "%Y-%m-%d %H:%M:%S", &tm_info);
+    return std::string(buf);
+  }
+}; // class ThrainLogger
+
+#endif

--- a/lib/logger.h
+++ b/lib/logger.h
@@ -144,7 +144,7 @@ private:
   std::string currentDateTime() {
     std::time_t now = std::time(nullptr);
     std::tm tm_info;
-#if defined(_MSC_VER)
+#if defined(_WIN32)
     localtime_s(&tm_info, &now);
 #else
     localtime_r(&now, &tm_info);

--- a/lib/makelib
+++ b/lib/makelib
@@ -8,7 +8,7 @@ CC=g++ --std=c++14
 
 ## files needed to compile stellar models
 #  dependencies
-LIBDEPS = Splinor.h  chandra.h   stellar.h   rootfind.h string.h
+LIBDEPS = Splinor.h  chandra.h   stellar.h   rootfind.h   string.h  logger.h
 #  source
 LIBSRC = Splinor.cpp chandra.cpp stellar.cpp rootfind.cpp string.cpp
 

--- a/lib/matrix.h
+++ b/lib/matrix.h
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <stdio.h>
 #include <assert.h>
+#include "logger.h"
 
 #ifndef MATRIX
 #define MATRIX
@@ -50,14 +51,14 @@ void add_rows(T (&m)[N], std::size_t i, std::size_t j, T coeff=1.0){
 }
 
 template <std::size_t N, std::size_t M, class T>
-void print_matrix(const T (&m)[N][M], int k=0){
-	printf("MATRIX %d\n", k);
+void print_matrix(const T (&m)[N][M], int k=0, ThrainLogger::LogLevel level = ThrainLogger::LogLevel::DEBUG){
+	ThrainLogger::log(level, "MATRIX %d\n", k);
 	for(std::size_t i=0; i<N; i++){
-		printf("\t[");
+		ThrainLogger::log(level, "\t[");
 		for(std::size_t j=0; j<M; j++){
-			printf("\t%lf,", m[i][j]);
+			ThrainLogger::log(level, "\t%lf,", m[i][j]);
 		}
-		printf("]\n");
+		ThrainLogger::log(level, "]\n");
 	}
 }
 
@@ -174,7 +175,7 @@ int invertMatrix(T (&m)[N][N], T (&b)[N], T (&x)[N]){
 	for(int i=0; i<N; i++){
 		if( (x[i]-x[i]) != T(0) ) produced_nan = true;
 	}
-	if(produced_nan){printf("ERROR in invertMatrix: NaNs produced\n"); return 1;}
+	if(produced_nan){ThrainLogger::error("ERROR in invertMatrix: NaNs produced\n"); return 1;}
 	return 0;
 }
 

--- a/lib/rootfind.hxx
+++ b/lib/rootfind.hxx
@@ -2,6 +2,7 @@
 #define ROOTFINDHXX
 
 #include "matrix.h"
+#include "logger.h"
 
 // *************************************************************************************
 //					NEWTON METHODS
@@ -80,7 +81,7 @@ void rootfind::newton_search(
 		if(matrix::invertMatrix(dfdx, f2, dx)){
 			//if the matrix is singular or otherwise fails
 			// then do something to try to recover
-			printf("ERROR: Matrix inversion failed!\nTrying to recover with past value.\n");
+			ThrainLogger::error("ERROR: Matrix inversion failed!\nTrying to recover with past value.\n");
 			//use the last gradient
 			double scale = rootfind::pseudo_unif();
 			for(int i=0; i<np; i++) dx[i] = scale*dxsave[i];

--- a/lib/stellar.h
+++ b/lib/stellar.h
@@ -22,7 +22,7 @@ struct Abundance {
 	int e;
 	double mean_A() const {
 		using namespace chemical;
-	//	printf("\tmuA:\t%0.2f\t%0.2f\t%0.2f\t%0.2f\n", H1, He4, C12, O16);
+		ThrainLogger::debug("\tmuA:\t%0.2f\t%0.2f\t%0.2f\t%0.2f\n", H1, He4, C12, O16);
 		return 1./(H1 + He4/chemical::A[he] + C12/chemical::A[c] + O16/chemical::A[o]);
 	}
 	double mean_Z() const {
@@ -45,7 +45,7 @@ struct Abundance {
 			+ O16*pow(chemical::Z[ o],2)*pow(chemical::A[ o],-1./3.) ;
 	}
 	void print() const {
-		printf("%0.2f\t%0.2f\t%0.2f\t%0.2f\n", H1, He4, C12, O16);
+		ThrainLogger::info("%0.2f\t%0.2f\t%0.2f\t%0.2f\n", H1, He4, C12, O16);
 	}
 	Abundance() :H1(0), He4(0), C12(0), O16(0), e(0) {};
 	Abundance(double x1, double x2, double x3, double x4) 

--- a/src/STARS/ChandrasekharWD++.cpp
+++ b/src/STARS/ChandrasekharWD++.cpp
@@ -123,12 +123,12 @@ ChandrasekharWD::ChandrasekharWD( double Y0, std::size_t L, const double dxi, Ch
 
 	indexFit = 512*round(double(len)/1024.0);
 	indexFit /= 2;
-	printf("  indexFit  = %lu\n", indexFit);
-	printf("r[indexFit] = %0.32le\n", rad(indexFit));
+	ThrainLogger::debug("  indexFit  = %lu\n", indexFit);
+	ThrainLogger::debug("r[indexFit] = %0.32le\n", rad(indexFit));
 	
 	setupCenter();
 	setupSurface();
-	printf("%0.2lf\t%le\t%le\n", 1./Y02, mr(len-1)/MSOLAR, rad(len-1));
+	ThrainLogger::info("%0.2lf\t%le\t%le\n", 1./Y02, mr(len-1)/MSOLAR, rad(len-1));
 }
 
 //initalize white dwarf from central value of y and length
@@ -168,7 +168,7 @@ ChandrasekharWD::ChandrasekharWD( double Y0, std::size_t L, double const A0, dou
 	indexFit /= 2;
 	setupCenter();
 	setupSurface();
-	printf("%0.8lf\t%le\t%le\n", 1./Y02, mr(len-1)/MSOLAR, rad(len-1));
+	ThrainLogger::info("%0.8lf\t%le\t%le\n", 1./Y02, mr(len-1)/MSOLAR, rad(len-1));
 }
 
 ChandrasekharWD::~ChandrasekharWD(){
@@ -553,15 +553,15 @@ int ChandrasekharWD::read_star_input(FILE* input_file, Calculation::InputData& c
 	
 	calcdata.input_params.resize(3);
 	fscanf(input_file, " %lf", &calcdata.input_params[0]);	//read in the central y value
-	printf("y0=%lf\n", calcdata.input_params[0]);
+	ThrainLogger::debug("y0=%lf\n", calcdata.input_params[0]);
 	//read in an integer designating the chemical composition to use for mu
 	fscanf(input_file, " %lf", &calcdata.input_params[1]);
 	switch((int) calcdata.input_params[1]){
 		case 0:
-			printf("standard Chandrasekhar WD\n");
+			ThrainLogger::info("standard Chandrasekhar WD\n");
 			break;
 		case 1:
-			printf("using logistic composition\n");
+			ThrainLogger::info("using logistic composition\n");
 			break;
 	}
 	fscanf(input_file, "%lf\n", &calcdata.input_params[2]);	//read in the grid size

--- a/src/STARS/MESA.cpp
+++ b/src/STARS/MESA.cpp
@@ -18,19 +18,19 @@
 #include "MESA.h"
 
 MESA::MESA(const char* filename, std::size_t L) : len(L) {
-	printf("Beginning read-in of MESA data.\n");
+	ThrainLogger::info("Beginning read-in of MESA data.\n");
 	FILE *infile;
 	if( !(infile = fopen(filename, "r")) ) {
-		printf("No such file %s\n", filename);
-		printf("In directory: ");fflush(stdout);
+		ThrainLogger::error("No such file %s\n", filename);
+		ThrainLogger::error("In directory: ");
 		system("pwd");
-		printf("Available files:\n");fflush(stdout);
+		ThrainLogger::error("Available files:\n");
 		system("ls");
 		exit(1);
 	}  
 	fscanf(infile, "  %lu    %le     %le     %le     %*d\n", &Ntot, &Mstar, &Rstar, &Lstar);
-	printf("\tMass = %0.2lg\tRadis = %0.2lg\tLuminosity = %0.2lg\n", Mstar, Rstar, Lstar);
-	printf("Number of grid points in MESA calculation %lu\n", Ntot);
+	ThrainLogger::info("\tMass = %0.2lg\tRadis = %0.2lg\tLuminosity = %0.2lg\n", Mstar, Rstar, Lstar);
+	ThrainLogger::info("Number of grid points in MESA calculation %lu\n", Ntot);
 	name = strmakef("MESA.M%1.2g.R%1.2g.L%1.2g", Mstar, Rstar, Lstar);
 			
 	//read through file once to get the max values of R,M
@@ -73,7 +73,7 @@ MESA::MESA(const char* filename, std::size_t L) : len(L) {
 	double Tscale = 2.*proton.mass_CGS/boltzmann_k*G_CGS*Mtot/Rtot;
 	ts[0] /= Tscale;
 	
-	printf("Done reading in data!\n");
+	ThrainLogger::info("Done reading in data!\n");
 	fclose(infile);
 	
 	//divide intervals up into binary fractions
@@ -82,7 +82,7 @@ MESA::MESA(const char* filename, std::size_t L) : len(L) {
 	if(n < 1) n = 1; //must at least divide each interval in half
 	len = pow(2,int(n))*(Ntot-1) + 1;
 	subgrid = pow(2,int(n));
-	printf("number of grid points to be used %lu\n", len);
+	ThrainLogger::info("number of grid points to be used %lu\n", len);
 			
 	radi = new double[len];
 	std::size_t kk=0;
@@ -169,14 +169,14 @@ double MESA::Gee()   {return G_CGS;} //Newton's constant in appropriate units
 double MESA::rad(std::size_t X){
 	if(X>=0 & X<len) return Rtot*radi[X];
 	else {
-		printf("\nradius out of range\n");	
+		ThrainLogger::error("\nradius out of range\n");	
 		return nan("");
 	}
 }
 double MESA::rho(std::size_t X){
 	if(X>=0 & X<len) return Dscale*dens->interp(radi[X]);
 	else {
-		printf("\nrho out of range\n");	
+		ThrainLogger::error("\nrho out of range\n");	
 		return nan("");
 	}
 }
@@ -184,14 +184,14 @@ double MESA::drhodr(std::size_t X){
 	if(X==0) return 0.0;
 	else if(X>0 & X<len) return Dscale/Rtot*dens->deriv(radi[X]);
 	else {
-		printf("\ndrhodr out of range\n");	
+		ThrainLogger::error("\ndrhodr out of range\n");	
 		return nan("");
 	}
 }
 double MESA::P(std::size_t X){
 	if(X>=0 & X<len) return Pscale*pres->interp(radi[X]);
 	else {
-		printf("\nP out of range\n");	
+		ThrainLogger::error("\nP out of range\n");	
 		return nan("");
 	}
 }
@@ -199,7 +199,7 @@ double MESA::dPdr(std::size_t X){
 	if(X==0) return 0.0;
 	else if(X>0 & X<len) return Pscale/Rtot*pres->deriv(radi[X]);
 	else {
-		printf("\ndPdr out of range\n");	
+		ThrainLogger::error("\ndPdr out of range\n");	
 		return nan("");
 	}
 }
@@ -707,7 +707,7 @@ void MESA::writeStar(const char *const c){
 	if(!(fp = fopen(txtname.c_str(), "w")) ){
 		system( ("mkdir -p " + filename).c_str() );
 		if(!(fp = fopen(txtname.c_str(), "w"))) 
-			printf("big trouble, boss\n");		
+			ThrainLogger::error("big trouble, boss\n");		
 	}
 	//print results to text file
 	// radius rho pressure gravity

--- a/src/STARS/Polytrope.cpp
+++ b/src/STARS/Polytrope.cpp
@@ -21,7 +21,7 @@ void Polytrope::basic_setup(){
 	//if index is out of range, fail
 	if( n > 5.0 || n < 0.0 ){
 		n = nan(""); len = 0;
-		printf("\nInvalid polytropic index.  Polytrope not initialized.\n");
+		ThrainLogger::error("\nInvalid polytropic index.  Polytrope not initialized.\n");
 		exit(EXIT_FAILURE);
 	}
 	//name this polytrope for files
@@ -163,9 +163,9 @@ Polytrope::Polytrope(double n, std::size_t L, const double dx)
 	
 	init_arrays();
 	indexFit = 256*round(double(len)/1024.0);
-	printf("  indexFit  = %lu\n", indexFit);
-	printf("r[indexFit] = %0.32le\t", rad(indexFit));
-	printf("y[indexFit] = %0.32le\n", Y[indexFit][y]);
+	ThrainLogger::debug("  indexFit  = %lu\n", indexFit);
+	ThrainLogger::debug("r[indexFit] = %0.32le\t", rad(indexFit));
+	ThrainLogger::debug("y[indexFit] = %0.32le\n", Y[indexFit][y]);
 	setupCenter();
 	setupSurface();
 }
@@ -483,7 +483,7 @@ int Polytrope::read_star_input(FILE* input_file, Calculation::InputData& calcdat
 	fscanf(input_file, " %lf\n", &grid_size);	//read in the grid size
 	calcdata.input_params.push_back(index);
 	calcdata.input_params.push_back(grid_size);
-	printf("n=%1.3lf\n", calcdata.input_params[0]);
+	ThrainLogger::info("n=%1.3lf\n", calcdata.input_params[0]);
 	calcdata.Ngrid = std::size_t(calcdata.input_params[1]);
 	
 	//now read in desired physical properties of star -- specify two at a time
@@ -507,26 +507,26 @@ int Polytrope::read_star_input(FILE* input_file, Calculation::InputData& calcdat
 	else if(instring == "zsurf")  {calcdata.zsurf =temp; calcdata.params|=units::ParamType::pzsurf;}
 	else if(instring == "logg")   {calcdata.logg  =temp; calcdata.params|=units::ParamType::plogg;}
 	else {
-		printf("ERROR IN INPUT: invalid parameter to polytope:\n allowed mass, radius, zsurf, or logg\n");
-		printf("This error is fatal.  Quitting.\n");
+		ThrainLogger::error("ERROR IN INPUT: invalid parameter to polytope:\n allowed mass, radius, zsurf, or logg\n");
+		ThrainLogger::error("This error is fatal.  Quitting.\n");
 		return 1;
 	}
 	//make sure we did not specify the same parameter twice
 	if(calcdata.params == tempparam){
-		printf("ERROR IN INPUT: double specification of stellar parameters, star underdefined\n");
-		printf("This error is fatal.  Quitting.\n");
+		ThrainLogger::error("ERROR IN INPUT: double specification of stellar parameters, star underdefined\n");
+		ThrainLogger::error("This error is fatal.  Quitting.\n");
 		switch(units::ParamType(calcdata.params)){
-			case units::ParamType::pmass:   printf("\tmass given twice\n"); break;
-			case units::ParamType::pradius: printf("\tradius given twice\n"); break;
-			case units::ParamType::pzsurf:  printf("\tzsurf given twice\n"); break;
-			case units::ParamType::plogg:   printf("\tlog g given twice\n"); break;
-			case units::ParamType::pteff:   printf("\tteff given twice\n"); break;
+			case units::ParamType::pmass:   ThrainLogger::error("\tmass given twice\n"); break;
+			case units::ParamType::pradius: ThrainLogger::error("\tradius given twice\n"); break;
+			case units::ParamType::pzsurf:  ThrainLogger::error("\tzsurf given twice\n"); break;
+			case units::ParamType::plogg:   ThrainLogger::error("\tlog g given twice\n"); break;
+			case units::ParamType::pteff:   ThrainLogger::error("\tteff given twice\n"); break;
 		}
 		return 1;
 	}	
 	if((calcdata.params&units::ParamType::pteff)){
-		printf("ERROR IN INPUT: polytropes cannot be assigned temperature\n");
-		printf("This error is fatal.  Quitting.\n");
+		ThrainLogger::error("ERROR IN INPUT: polytropes cannot be assigned temperature\n");
+		ThrainLogger::error("This error is fatal.  Quitting.\n");
 		return 1;
 	}
 

--- a/src/STARS/SimpleWD.cpp
+++ b/src/STARS/SimpleWD.cpp
@@ -105,15 +105,15 @@ SimpleWD::SimpleWD(
 	Xtot  = massFraction();
 	Xmass = Xtot;
 	
-	printf("star  :\t M=%le\tR=%le\tL=%le\n", Msolar, Rsolar, Lsolar);
+	ThrainLogger::info("star  :\t M=%le\tR=%le\tL=%le\n", Msolar, Rsolar, Lsolar);
 	name = strmakef("WD_M%0.2f_L%0.2f_X%0.2f_Y%0.2f", Msolar, Rsolar, Xtot[0], Xtot[1]);
 	// find relevant scales for re-dimensionalizing the quantities
 	Dscale = Mstar*pow(Rstar,-3)/(4.*m_pi);
 	Pscale = G_CGS*pow(Mstar,2)*pow(Rstar,-4)/(4.*m_pi);
 	Tscale = Xtot.mean_A()*proton.mass_CGS/boltzmann_k*G_CGS*Mstar/Rstar;
-	printf("scales:\t M=%le\tR=%le\tL=%le\n", Mstar, Rstar, Lstar);
-	printf("scales:\t D=%le\tP=%le\tT=%le\n", Dscale, Pscale, Tscale);
-	printf("Xtot  :\t %0.8lf %0.8lf %0.8lf %0.8lf\n", Xtot[0],Xtot[1],Xtot[2],Xtot[3]);
+	ThrainLogger::debug("scales:\t M=%le\tR=%le\tL=%le\n", Mstar, Rstar, Lstar);
+	ThrainLogger::debug("scales:\t D=%le\tP=%le\tT=%le\n", Dscale, Pscale, Tscale);
+	ThrainLogger::debug("Xtot  :\t %0.8lf %0.8lf %0.8lf %0.8lf\n", Xtot[0],Xtot[1],Xtot[2],Xtot[3]);
 	
 	Yscale = StellarVar(Dscale,Rstar,Pscale,Mstar,Tscale,Lstar);
 	logYscale = log(Yscale);
@@ -121,7 +121,7 @@ SimpleWD::SimpleWD(
 	Ystar  = StellarVar(  0.0 , Rstar,  0.0 , Mstar,  0.0 , Lstar );
 			
 	//begin the calculation to find values for P0, T0, and Rstar = (1+qs)*R
-	printf("Converging model to P0, T0, R\n");
+	ThrainLogger::info("Converging model to P0, T0, R\n");
 	double P0 = Ystart0[pres]/Pscale;//dimensionless
 	double T0 = 1.e3*Teff/Tscale; //dimensionless
 	double qs = 1.e-3;
@@ -136,12 +136,16 @@ SimpleWD::SimpleWD(
 	int count=1;
 	double maxDF = 1.0;
 	while( maxDF > 1.0e-10 ){
-		printf("ITERATION: %d\n", count++);
+		ThrainLogger::info("ITERATION: %d\n", count++);
 		//recompute difference, and Jacobian matrix
 		joinAtCenter(x, f, F);
-		printf("\tX1:\t"); for(int i=0; i<numv; i++) printf("%le ", x[i]); printf("\n");
-		printf("\tf1:\t"); for(int i=0; i<numv; i++) printf("%le ", f[i]); printf("\n");
-		printf("\tF1:\t%le\n", F);
+		ThrainLogger::debug("\tX1:\t");
+		for(int i=0; i<numv; i++) ThrainLogger::debug("%le ", x[i]);
+		ThrainLogger::debug("\n");
+		ThrainLogger::debug("\tf1:\t");
+		for(int i=0; i<numv; i++) ThrainLogger::info("%le ", f[i]);
+		ThrainLogger::debug("\n");
+		ThrainLogger::debug("\tF1:\t%le\n", F);
 		
 		//calculate a Jacobian matrix by varying each variable
 		for(int i=0; i<numv; i++) varied[i] = 1.01*x[i];
@@ -162,7 +166,7 @@ SimpleWD::SimpleWD(
 		if(matrix::invertMatrix(dfdx,f2, dx)){
 			//if the matrix is singular or otherwise fails
 			// then just do something to try to recover
-			printf("ERROR: Matrix inversion failed!\n");
+			ThrainLogger::error("ERROR: Matrix inversion failed!\n");
 			//use the last gradient
 			for(int i=0; i<numv; i++) dx[i] = dxsave[i];
 		}
@@ -173,7 +177,7 @@ SimpleWD::SimpleWD(
 		bool allzero = true;
 		for(int i=0; i<numv; i++) allzero &= (dx[i] == 0.0);
 		if(allzero) for(int i=0; i<numv; i++) {
-			printf("all zero:\t%le %le\n", dx[0], dx[1]);
+			ThrainLogger::error("all zero:\t%le %le\n", dx[0], dx[1]);
 			dx[i] = 0.1*x[i];
 		}
 	
@@ -184,7 +188,9 @@ SimpleWD::SimpleWD(
 		while(negative){
 			for(int i=0; i<numv; i++) dx[i] *= 0.1;
 			for(int i=0; i<numv; i++) x2[i] = x[i]+dx[i];
-			printf("\tX2:\t"); for(int i=0; i<numv; i++) printf("%le ", x2[i]); printf("\n");
+			ThrainLogger::debug("\tX2:\t");
+			for(int i=0; i<numv; i++) ThrainLogger::debug("%le ", x2[i]);
+			ThrainLogger::debug("\n");
 			negative = false;
 			for(int i=0; i<numv; i++) if(x2[i]<z[i]) negative=true;	
 		}
@@ -197,22 +203,28 @@ SimpleWD::SimpleWD(
 			for(int i=0; i<numv; i++) x2[i] = x[i] + L*dx[i];
 			joinAtCenter(x2, f2, F2);
 		}
-		printf("\tdx:\t"); for(int i=0; i<numv; i++) printf("%le ", L*dx[i]); printf("\n");
+		ThrainLogger::debug("\tdx:\t");
+		for(int i=0; i<numv; i++) ThrainLogger::debug("%le ", L*dx[i]);
+		ThrainLogger::debug("\n");
 		F = F2;
 		for(int i=0; i<numv; i++) f[i] = f2[i];
 		for(int i=0; i<numv; i++) x[i] = x2[i];
 		
-		printf("\tX2:\t"); for(int i=0; i<numv; i++) printf("%le ", x[i]); printf("\n");
-		printf("\tf2:\t"); for(int i=0; i<numv; i++) printf("%le ", f[i]); printf("\n");
-		printf("\tF2:\t%le\n", F);
+		ThrainLogger::debug("\tX2:\t");
+		for(int i=0; i<numv; i++) ThrainLogger::debug("%le ", x[i]);
+		ThrainLogger::debug("\n");
+		ThrainLogger::debug("\tf2:\t");
+		for(int i=0; i<numv; i++) ThrainLogger::debug("%le ", f[i]);
+		ThrainLogger::debug("\n");
+		ThrainLogger::debug("\tF2:\t%le\n", F);
 				
 		// determine the max size of the differences
 		maxDF = -1.0;
 		for(int i=0; i<numv; i++) if(fabs(f[i]) > maxDF) maxDF = fabs(f[i]);		
-		printf("MAX DIF = %le\n", maxDF);
+		ThrainLogger::info("MAX DIF = %le\n", maxDF);
 	}
 	
-	printf("MODEL CONVERGED!\n");
+	ThrainLogger::info("MODEL CONVERGED!\n");
 	joinAtCenter(x,f,F);
 	
 	//all done!  begin post-production
@@ -224,8 +236,8 @@ SimpleWD::SimpleWD(
 	if(Ncore%2==1) Ncore = Ncore - 1;
 	indexFit = (Ncore)/2;
 	
-	printf("Teff=%le\tTsurf=%le\n", Teff, Tscale*exp(logY[Ntot-1][temp]));
-	printf("Xtot :\t%0.8lf %0.8lf %0.8lf %0.8lf\n", Xtot.H1 , Xtot.He4 , Xtot.C12 , Xtot.O16);
+	ThrainLogger::info("Teff=%le\tTsurf=%le\n", Teff, Tscale*exp(logY[Ntot-1][temp]));
+	ThrainLogger::info("Xtot :\t%0.8lf %0.8lf %0.8lf %0.8lf\n", Xtot.H1 , Xtot.He4 , Xtot.C12 , Xtot.O16);
 		
 	setupCenter();
 	setupSurface();
@@ -250,7 +262,7 @@ SimpleWD::~SimpleWD(){
 void SimpleWD::setup(){
 	FILE *input_file;
 	if(!(input_file=fopen("swd.txt", "r"))){
-		printf("ERROR: EOS file not found... using a default\n");
+		ThrainLogger::warning("ERROR: EOS file not found... using a default\n");
 		//do something
 		std::vector<PartialPressure> corePres{deg_zero, rad_gas, ideal, coul};
 		std::vector<PartialPressure> atmPres{rad_gas, ideal};
@@ -266,17 +278,17 @@ void SimpleWD::setup(){
 	std::string instring;
 	EOS *pres = NULL;
 	char *c = std::fgets(input_buffer, buffer_size, input_file);
-	printf("%s", input_buffer);fflush(stdout);
+	ThrainLogger::debug("%s", input_buffer);
 	while(c != nullptr){
 		c = std::fgets(input_buffer, buffer_size, input_file);
-		if(c != nullptr) printf("%s", input_buffer);
+		if(c != nullptr) ThrainLogger::debug("%s", input_buffer);
 		if(     !strcmp(input_buffer, "core:\n")) pres = &core_pressure;
 		else if(!strcmp(input_buffer, "atm:\n"))  pres = &atm_pressure;
 		if(pres!=NULL){
 			std::fgets(input_buffer, buffer_size, input_file);
 			pressure = strtok(input_buffer, " \t\n");
 			while(pressure != NULL){
-				printf("\t%s", pressure);
+				ThrainLogger::debug("\t%s", pressure);
 				if(     !strcmp(pressure, "rad"))
 					pres->push_back(rad_gas);
 				else if(!strcmp(pressure, "ideal"))
@@ -291,10 +303,10 @@ void SimpleWD::setup(){
 					pres->push_back(deg_finite);
 				else if(!strcmp(pressure, "deg_trap"))
 					pres->push_back(deg_trap);
-				else printf("ERROR: partial pressure term unrecognized!\n");
+				else ThrainLogger::error("ERROR: partial pressure term unrecognized!\n");
 				pressure = strtok(NULL, " \t\n");
 			}
-			printf("\n");
+			ThrainLogger::debug("\n");
 		}
 		if(!strcmp(input_buffer, "# chemical parameters\n")) {
 			fscanf(input_file, "%*[^0123456789] %lf %lf %lf\n", &zy, &by, &my);
@@ -303,13 +315,13 @@ void SimpleWD::setup(){
 		}
 		pres = NULL;
 	}
-	printf("\the\t%lf\t%lf\t%lf\n", zy, by, my);
-	printf("\tc \t%lf\t%lf\t%lf\n", zc, bc, mc);
-	printf("\to \t%lf\t%lf\t%lf\n", zo, bo, mo);
+	ThrainLogger::debug("\the\t%lf\t%lf\t%lf\n", zy, by, my);
+	ThrainLogger::debug("\tc \t%lf\t%lf\t%lf\n", zc, bc, mc);
+	ThrainLogger::debug("\to \t%lf\t%lf\t%lf\n", zo, bo, mo);
 }
 
 void SimpleWD::initFromChandrasekhar(){
-	printf("Preparing starting values from Chandrasekhar model\n");
+	ThrainLogger::info("Preparing starting values from Chandrasekhar model\n");
 	Mstar = Msolar*MSOLAR;
 	std::size_t Ntest = 500;
 	double y0 = 1.58,  ymin = 1.0, ymax = 20.0;
@@ -348,11 +360,11 @@ void SimpleWD::initFromChandrasekhar(){
 	YstartS[dens] = testStar->rho(Ntest-2);
 	YstartS[pres] = testStar->P(Ntest-2);
 	
-	printf("Radius in CM: %le\n", Rstar);
-	printf("Radius in RE: %le\n", Rsolar);
+	ThrainLogger::info("Radius in CM: %le\n", Rstar);
+	ThrainLogger::info("Radius in RE: %le\n", Rsolar);
 	
-	printf("Core guess: %le \t %le\n", Ystart0[pres], Ystart0[dens]);
-	printf("Surf guess: %le \t %le\n", YstartS[pres], YstartS[dens]);
+	ThrainLogger::info("Core guess: %le \t %le\n", Ystart0[pres], Ystart0[dens]);
+	ThrainLogger::info("Surf guess: %le \t %le\n", YstartS[pres], YstartS[dens]);
 	return;
 }
 
@@ -989,8 +1001,8 @@ double SimpleWD::equationOfState(const StellarVar& logy, const Abundance& chem, 
 	double Prad, rho=0.0;
 	Prad = radiation_a/3.*pow(y[temp],4);
 	if(Prad > y[pres]) {
-		printf("\nERROR: RADIATION PRESSURE TOO HIGH!\n");
-		printf("X %d:\tr=%le m=%le P=%le T=%le\n", X, exp(logy[radi]), exp(logy[mass]), exp(logy[pres]), exp(logy[temp]));
+		ThrainLogger::error("\nERROR: RADIATION PRESSURE TOO HIGH!\n");
+		ThrainLogger::error("X %d:\tr=%le m=%le P=%le T=%le\n", X, exp(logy[radi]), exp(logy[mass]), exp(logy[pres]), exp(logy[temp]));
 		//do something to try to recover
 		y[pres] += Prad;
 		logY[X][pres] = std::log(y[pres]);
@@ -999,9 +1011,9 @@ double SimpleWD::equationOfState(const StellarVar& logy, const Abundance& chem, 
 	rho = getEOS(y, chem)->invert(rho_last, y[pres], y[temp], chem);
 
 	if(rho<0.0) rho = -rho;
-	if(std::isnan(rho)) printf("RHO IS NAN!\n");
+	if(std::isnan(rho)) ThrainLogger::error("RHO IS NAN!\n");
 	if(std::isnan(log(rho))){
-		printf("%le %le %le %le %le %le\n", exp(logy[radi]), y[pres], y[temp], rho, rho/Dscale, log(rho/Dscale));
+		ThrainLogger::error("%le %le %le %le %le %le\n", exp(logy[radi]), y[pres], y[temp], rho, rho/Dscale, log(rho/Dscale));
 	}
 	
 	//save the density	
@@ -1230,14 +1242,14 @@ void SimpleWD::setupCenter(){
 	pc[0] = exp(logY[0][pres]);
 	tc[0] = exp(logY[0][temp]);
 	double del = nabla[0];
-	printf("Establishing center:\n");
-	printf("x^0:\t%le %le %le %le\n", dc[0], pc[0], tc[0], del);
+	ThrainLogger::debug("Establishing center:\n");
+	ThrainLogger::debug("x^0:\t%le %le %le %le\n", dc[0], pc[0], tc[0], del);
 	
 	//terms x^2
 	tc[1] = -del*tc[0]*dc[0]*dc[0]/6./pc[0];
 	pc[1] = -dc[0]*dc[0]/6.;
 	dc[1] = (pc[1] - tc[1]*dPdt)/dPdd;
-	printf("x^2:\t%le %le %le\n", dc[1], pc[1], tc[1]);
+	ThrainLogger::debug("x^2:\t%le %le %le\n", dc[1], pc[1], tc[1]);
 	
 	//terms x^4
 	tc[2] = (5.*pc[1]*tc[0]*dc[0]*dc[0]-5.*pc[0]*tc[1]*dc[0]*dc[0]-8.*pc[0]*tc[0]*dc[0]*dc[1]);
@@ -1245,7 +1257,7 @@ void SimpleWD::setupCenter(){
 	pc[2] = -dc[0]*dc[1]*2./15.;
 	dc[2] = (2.*pc[2]-2.*tc[2]*dPdt
 			-tc[1]*tc[1]*dPdtt-2.*tc[1]*dc[1]*dPddt-dc[1]*dc[1]*dPddd)/(2.*dPdd);
-	printf("x^4:\t%le %le %le\n", dc[2], pc[2], tc[2]);
+	ThrainLogger::debug("x^4:\t%le %le %le\n", dc[2], pc[2], tc[2]);
 	
 	//now make the actual terms
 	// c
@@ -1938,7 +1950,7 @@ void SimpleWD::writeStar(const char *const c){
 	FILE *fp;
 	if(!(fp = fopen(txtname.c_str(), "w")) ){
 		system( ("mkdir -p " + filename).c_str() );
-		if(!(fp = fopen(filename.c_str(), "w"))) printf("big trouble, boss\n");		
+		if(!(fp = fopen(filename.c_str(), "w"))) ThrainLogger::error("big trouble, boss\n");		
 	}
 	
 	//print results to text file

--- a/src/ThrainIO.cpp
+++ b/src/ThrainIO.cpp
@@ -76,7 +76,7 @@ int read_input(const char input_file_name[128], Calculation::InputData &calcdata
 		calcdata.input_params.reserve(1);
 		fscanf(input_file, "%s ", input_buffer);    //read in the filename
 		calcdata.str_input_param=std::string(input_buffer);
-		printf("source=%s.dat\n", calcdata.str_input_param.c_str());
+		ThrainLogger::info("source=%s.dat\n", calcdata.str_input_param.c_str());
 		fscanf(input_file, "%lf\n", &calcdata.input_params[0]);	//read in the grid size
 		calcdata.Ngrid = int(calcdata.input_params[0]);
 	}
@@ -86,7 +86,7 @@ int read_input(const char input_file_name[128], Calculation::InputData &calcdata
 		calcdata.input_params.resize(10);
 		fscanf(input_file, "%lf\n", &calcdata.input_params[0]);	//read in the grid size
 		calcdata.Ngrid = int(calcdata.input_params[0]);
-		printf("Ngrid=%lu\n", calcdata.Ngrid);
+		ThrainLogger::info("Ngrid=%lu\n", calcdata.Ngrid);
 		
 		//on a new line, specify the EOS
 		FILE *swd = fopen("swd.txt", "w");
@@ -100,7 +100,7 @@ int read_input(const char input_file_name[128], Calculation::InputData &calcdata
 		fscanf(input_file, "\tatm\t%[^\n]\n", input_buffer);
 		fprintf(swd, "atm:\n\t%s\n\n", input_buffer);
 		calcdata.str_input_param += std::string(input_buffer);
-		printf("THRAIN MODEL EOS:\n%s\n", calcdata.str_input_param.c_str());
+		ThrainLogger::info("THRAIN MODEL EOS:\n%s\n", calcdata.str_input_param.c_str());
 		
 		//on a new line, specify chemical paramters
 		fscanf(input_file, "chemical parameters:\n");  //skip a line of formatting
@@ -124,8 +124,8 @@ int read_input(const char input_file_name[128], Calculation::InputData &calcdata
 		//save value in appropriate slot use bit-masking to keep track of variables
 		if(!instring.compare("mass")){ calcdata.mass = temp; calcdata.params|=units::ParamType::pmass;}
 		else {
-			printf("ERROR IN INPUT: first parameter to SimpleWD must be mass\n");
-			printf("This error is fatal.  Quitting.\n");
+			ThrainLogger::error("ERROR IN INPUT: first parameter to SimpleWD must be mass\n");
+			ThrainLogger::error("This error is fatal.  Quitting.\n");
 			return 1;
 		}
 		//read in second physical parameters -- name as string, value as double
@@ -134,21 +134,21 @@ int read_input(const char input_file_name[128], Calculation::InputData &calcdata
 		//save valeu in appropriate slot, again use bit-masking so that binary value of params indicates which were used
 		if(!instring.compare("teff")){ calcdata.teff = temp; calcdata.params|=units::ParamType::pteff;}
 		else {
-			printf("ERROR IN INPUT: second parameter to SimpleWD must be teff\n");
-			printf("This error is recoverable.  Using teff = 12 000 K\n");
+			ThrainLogger::warning("ERROR IN INPUT: second parameter to SimpleWD must be teff\n");
+			ThrainLogger::warning("This error is recoverable.  Using teff = 12 000 K\n");
 			calcdata.teff = 12000.0;
 			calcdata.params|=units::ParamType::pteff;
 		}
 		//double check we have both mass and effective temperature
 		char tempparam = units::ParamType::pmass|units::ParamType::pteff;
 		if(calcdata.params != tempparam){
-			printf("ERROR IN INPUT: a SimpleWD needs both mass and teff\n");
-			printf("This error is fatal.  Quitting.\n");
+			ThrainLogger::error("ERROR IN INPUT: a SimpleWD needs both mass and teff\n");
+			ThrainLogger::error("This error is fatal.  Quitting.\n");
 			return 1;	
 		}
-		printf("Making SimpleWD model with:\n");
-		printf("\tM=%le\n", calcdata.mass);
-		printf("\tTeff=%le\n", calcdata.teff);		
+		ThrainLogger::info("Making SimpleWD model with:\n");
+		ThrainLogger::info("\tM=%le\n", calcdata.mass);
+		ThrainLogger::info("\tTeff=%le\n", calcdata.teff);		
 	}
 		
 	//read the units to be used in calculation
@@ -166,9 +166,9 @@ int read_calcname(FILE* input_file, Calculation::InputData& calcdata){
 	char calculation_name[128];	//a label for this calculation
 	int filled = fscanf(input_file, "Name: %s\n", calculation_name);
 	calcdata.calcname = std::string(calculation_name);
-	printf("calculation name: %s\n", calcdata.calcname.c_str());
+	ThrainLogger::info("calculation name: %s\n", calcdata.calcname.c_str());
 	if(!filled || filled==EOF) {
-		printf("ERROR IN INPUT: no calculation name given.\n");
+		ThrainLogger::error("ERROR IN INPUT: no calculation name given.\n");
 		return 1;
 	}
 	else return 0;
@@ -182,24 +182,24 @@ int read_model(FILE* input_file, Calculation::InputData& calcdata){
 	instring = std::string(input_buffer);
 	if(!instring.compare("newtonian")) calcdata.regime = regime::PN0;
 	else{
-		printf("ERROR IN INPUT: THRAIN only knows Newtonian physics!\n");
-		printf("This error is recoverable!  Setting to proper regime.\n");
+		ThrainLogger::warning("ERROR IN INPUT: THRAIN only knows Newtonian physics!\n");
+		ThrainLogger::warning("This error is recoverable!  Setting to proper regime.\n");
 		calcdata.regime = regime::PN0;
 	}
 	//read the background stellar model to be used in calculation
 	fscanf(input_file, "%s\t", input_buffer);
-	printf("MAKING A ");
+	ThrainLogger::debug("MAKING A ");
 	instring = std::string(input_buffer);
 	if(!instring.compare("polytrope")) calcdata.model = model::polytrope;
 	else if(!instring.compare("CHWD")) calcdata.model = model::CHWD;
 	else if(!instring.compare("MESA")) calcdata.model = model::MESA;
 	else if(!instring.compare("SWD"))  calcdata.model = model::SWD;
 	else {
-		printf("ERROR IN INPUT: THRAIN can only work with polytrope, CHWD, MESA, or SWD\n");
-		printf("This error is fatal.  Quitting.\n");
+		ThrainLogger::error("ERROR IN INPUT: THRAIN can only work with polytrope, CHWD, MESA, or SWD\n");
+		ThrainLogger::error("This error is fatal.  Quitting.\n");
 		return 1;
 	}
-	printf("%s\n", input_buffer);
+	ThrainLogger::logInline(ThrainLogger::LogLevel::DEBUG, "%s\n", input_buffer);
 
 	return 0;
 }
@@ -209,20 +209,20 @@ int read_units(FILE* input_file, Calculation::InputData& calcdata){
 	std::string instring;		//for more read-in from file
 
 	fscanf(input_file, "Units: %s\n", input_buffer);
-	printf("USING UNITS: ");
+	ThrainLogger::debug("USING UNITS: ");
 	instring = std::string(input_buffer);
 	if(!instring.compare("astro"))    calcdata.units = units::Units::astro;
 	else if(!instring.compare("geo")) calcdata.units = units::Units::geo;
 	else if(!instring.compare("SI"))  calcdata.units = units::Units::SI;
 	else if(!instring.compare("CGS")) calcdata.units = units::Units::CGS;
 	else{
-		printf("ERROR IN INPUT: units incorrectly written...\n");
-		printf("units: %s\n", input_buffer);
-		printf("units: %s\n", instring.c_str());
-		printf("This error is fatal.  Quitting.\n");
+		ThrainLogger::error("ERROR IN INPUT: units incorrectly written...\n");
+		ThrainLogger::error("units: %s\n", input_buffer);
+		ThrainLogger::error("units: %s\n", instring.c_str());
+		ThrainLogger::error("This error is fatal.  Quitting.\n");
 		return 1;
 	}
-	printf("%s\n", input_buffer);
+	ThrainLogger::logInline(ThrainLogger::LogLevel::DEBUG, "%s\n", input_buffer);
 	return 0;
 }
 
@@ -236,8 +236,8 @@ int read_frequencies(FILE* input_file, Calculation::InputData& calcdata){
 	else if(!instring.compare("nonradial"))   calcdata.modetype = modetype::nonradial;
 	else if(!instring.compare("cowling"))     calcdata.modetype = modetype::cowling;
 	else{
-		printf("ERROR IN INPUT: THRAIN can only compute nonradial modes.\n");
-		printf("This error is recoverable.  Changing mode type.");
+		ThrainLogger::warning("ERROR IN INPUT: THRAIN can only compute nonradial modes.\n");
+		ThrainLogger::warning("This error is recoverable.  Changing mode type.");
 		calcdata.modetype = modetype::nonradial;
 	}
 	//read in the adiabatic index for the mode calculation
@@ -258,7 +258,7 @@ int read_frequencies(FILE* input_file, Calculation::InputData& calcdata){
 		fscanf(input_file, "%s\n", input_buffer);
 		calcdata.mode_num++;
 	}
-	printf("Number of frequencies: %lu\n", calcdata.mode_num);
+	ThrainLogger::error("Number of frequencies: %lu\n", calcdata.mode_num);
 	fseek(input_file, startoflist, SEEK_SET); //return to start of list
 	//now read in the L,K as specified 
 	for(int j=0; j<calcdata.mode_num; j++){
@@ -287,7 +287,7 @@ int read_frequencies(FILE* input_file, Calculation::InputData& calcdata){
 
 //this function will print back the input file, so the same calculation can be run again
 int echo_input(Calculation::InputData &calcdata){
-	printf("Copying input file...\t"); fflush(stdout);
+	ThrainLogger::info("Copying input file...\t");
 	//open file to write output summary
 	std::string output_file_name = "./output/"+calcdata.calcname+"/"+calcdata.calcname+"_in.txt";
 	FILE* output_file;
@@ -297,7 +297,7 @@ int echo_input(Calculation::InputData &calcdata){
 		//if an error occurs, try making the folder needed
 		system( ("mkdir -p ./output/"+calcdata.calcname).c_str() );
 		if( !(output_file = fopen(output_file_name.c_str(), "w")) ){
-			printf("output file not found.\n");
+			ThrainLogger::error("output file not found.\n");
 			return 1;
 		}
 	}
@@ -390,18 +390,18 @@ int echo_input(Calculation::InputData &calcdata){
 		}
 	}
 	if(checkcount != calcdata.mode_num){
-		printf("non-matching numbers of modes");
+		ThrainLogger::error("non-matching numbers of modes");
 		return 1;
 	}
 	
-	printf("done\n");
+	ThrainLogger::logInline(ThrainLogger::LogLevel::INFO, "done\n");
 	fflush(output_file);
 	fclose(output_file);
 	return 0;
 }
 
 int setup_output(Calculation::InputData &data_in, Calculation::OutputData &data_out){
-	printf("Preparing calculation data...\n"); fflush(stdout);
+	ThrainLogger::info("Preparing calculation data...\n");
 	//read in the basic properties for the calculation
 	data_out.calcname = data_in.calcname;
 	data_out.regime = data_in.regime;
@@ -421,9 +421,9 @@ int setup_output(Calculation::InputData &data_in, Calculation::OutputData &data_
 	data_out.teff = data_in.teff;
 	data_out.params = data_in.params;
 	//formatting units may need to be re-performed after calculation, depending on star
-	printf("MASS = %le\n", data_out.mass);
+	ThrainLogger::info("MASS = %le\n", data_out.mass);
 	units::format_units(data_out);
-	printf("MASS = %le\n", data_out.mass);
+	ThrainLogger::info("MASS = %le\n", data_out.mass);
 	
 	//now prepare the modes
 	data_out.mode_num = data_in.mode_num;
@@ -467,7 +467,7 @@ int setup_output(Calculation::InputData &data_in, Calculation::OutputData &data_
 	//create the error columns
 	data_out.err = new double*[data_out.i_err];
 	for(int e=0; e<data_out.i_err; e++) data_out.err[e] = new double[data_out.mode_num];
-	printf("done\n");
+	ThrainLogger::info("done\n");
 	return 0;
 }
 
@@ -496,18 +496,18 @@ char dwarf[12][27] = {
 
 int write_stellar_output(Calculation::OutputData& calcdata){
 	int d=0;
-	printf("Writing stellar data to file...\t");fflush(stdout);
+	ThrainLogger::info("Writing stellar data to file...\t");
 	//open file to write output summary
 	std::string output_file_name = "./output/"+calcdata.calcname+"/"+calcdata.calcname+".txt";
 	FILE* output_file;
 	//try to open the output file
 	if( !(output_file = fopen(output_file_name.c_str(), "w")) ){
 		//if an error occurs, try making the folder needed
-		printf("creating file..."); fflush(stdout);
+		ThrainLogger::info("creating file...");
 		// std::string command = "mkdir -p ./output/"+calcdata.calcname;
 		system( ("mkdir -p ./output/"+calcdata.calcname).c_str() );
 		if( !(output_file = fopen(output_file_name.c_str(), "w")) ){
-			printf("output file not found.\n");
+			ThrainLogger::info("output file not found.\n");
 			return 1;
 		}
 	}
@@ -594,7 +594,7 @@ int write_stellar_output(Calculation::OutputData& calcdata){
 	fprintf(output_file,"%s  \n", dwarf[d++]);
 	
 
-	//printf the background model data
+	//print the background model data
 	switch(calcdata.model){
 		case model::polytrope:
 			fprintf(output_file, "%s  index n = %.2lf\n", dwarf[d++], calcdata.input_params[0]);
@@ -630,25 +630,25 @@ int write_stellar_output(Calculation::OutputData& calcdata){
 	std::string outname = "./output/"+calcdata.calcname;
 	calcdata.star->writeStar(outname.c_str());
 	
-	printf("done\n");
+	ThrainLogger::logInline(ThrainLogger::LogLevel::INFO, "done\n");
 	return 0;
 }
 
 int write_mode_output(Calculation::OutputData& calcdata){
-	printf("Writing mode data to file...\t"); fflush(stdout);
+	ThrainLogger::info("writing mode data to file...\t");
 	//open file to write output summary
 	std::string output_file_name = "./output/"+calcdata.calcname+"/"+calcdata.calcname+".txt";
 	FILE* output_file;
 	//try to open the output file
 	if( !(output_file = fopen(output_file_name.c_str(), "a")) ){
-		printf("the file doesn't exist\n");
+		ThrainLogger::error("the file doesn't exist\n");
 		return 1;
 	}
 		
 	int WIDTH = 86;
 	if(calcdata.mode_writ==0){
 		fprintf(output_file, "#  Stellar Pulsation Results  \n");
-		//Printf the adiabatic index used in calculation -- 5/3, 4/3 special cases
+		//Print the adiabatic index used in calculation -- 5/3, 4/3 special cases
 		fprintf(output_file, "#  Adiabatic exponent (Gamma1) ");
 		double a = calcdata.adiabatic_index*3.0;
 		if(fabs(a-5.0)<1e-10) fprintf(output_file, "= 5/3\n");
@@ -712,7 +712,7 @@ int write_mode_output(Calculation::OutputData& calcdata){
 	}
 
 	fclose(output_file);
-	printf("done\n");
+	ThrainLogger::logInline(ThrainLogger::LogLevel::INFO, "done\n");
 	return 0;
 }
 
@@ -730,17 +730,17 @@ void print_splash(FILE* output_file, const char *const title, int WIDTH){
 }
 
 int write_tidal_overlap(Calculation::OutputData& calcdata){
-	printf("Writing tidal overlap coefficients...\t");fflush(stdout);
+	ThrainLogger::info("Writing tidal overlap coefficients...\t");
 	//open file to write output summary
 	std::string output_file_name = "./output/"+calcdata.calcname+"/tidal_overlap.txt";
 	FILE* output_file;
 	//try to open the output file
 	if( !(output_file = fopen(output_file_name.c_str(), "w")) ){
 		//if an error occurs, try making the folder needed
-		printf("creating file...\n"); fflush(stdout);
+		ThrainLogger::info("creating file...\n");
 		system( ("mkdir -p ./output/"+calcdata.calcname).c_str() );
 		if( !(output_file = fopen(output_file_name.c_str(), "w")) ){
-			printf("output file not found.\n");
+			ThrainLogger::error("output file not found.\n");
 			return 1;
 		}
 	}
@@ -795,7 +795,7 @@ int write_tidal_overlap(Calculation::OutputData& calcdata){
 		fflush(output_file);
 	}
 	fclose(output_file);
-	printf("done\n");
+	ThrainLogger::logInline(ThrainLogger::LogLevel::INFO, "done\n");
 	return 0;
 }
 

--- a/src/ThrainMain.cpp
+++ b/src/ThrainMain.cpp
@@ -21,11 +21,11 @@ int main(int argc, char* argv[]){
 	if(argc == 2) {
 		//the calculation filename is sent as command-line argument
 		//call the read_input routine on the given filename (see GRPulseIO.h)
-		if(!io::read_input(argv[1], calcdataIn)) printf("file read\n");
+		if(!io::read_input(argv[1], calcdataIn)) ThrainLogger::info("file read\n");
 		else return 1;
 	}
 	else {
-		printf("Usage is thrain.out <input file>\n");
+		ThrainLogger::error("Usage is thrain.out <input file>\n");
 		return 1;
 	}
 	
@@ -46,6 +46,6 @@ int main(int argc, char* argv[]){
 	io::write_mode_output(calcdataOut);
 	if(calcdataOut.regime==regime::PN0 && calcdataOut.modetype==modetype::nonradial)
 		io::write_tidal_overlap(calcdataOut);
-	printf("THRAIN done\n");
+	ThrainLogger::info("THRAIN done\n");
 	return 0;
 }

--- a/src/ThrainMode.hxx
+++ b/src/ThrainMode.hxx
@@ -45,7 +45,7 @@ int mode_finder(Calculation::OutputData &data){
 	static_assert((std::is_base_of<ModeBase,MODE>::value), "first class must be mode");
 	static_assert((MODE::num_var==MODEDRIVER::num_var), "incompatible mode, mode class");
 
-	printf("num_var = %d\n", MODE::num_var);
+	ThrainLogger::debug("num_var = %d\n", MODE::num_var);
 	
 	//information on the nodes that need to be found
 	int num = data.mode_num;
@@ -79,7 +79,7 @@ int mode_finder(Calculation::OutputData &data){
 	int nextmode = 0;
 	for(auto lt=l_list.begin(); lt!=l_list.end(); lt++){
 		const int ltarget = *lt;
-		printf("L=%d\n", ltarget);
+		ThrainLogger::info("L=%d\n", ltarget);
 
 		std::set<int> kl = kl_lists[ltarget];
 		//these will be filled as we discover modes
@@ -94,20 +94,20 @@ int mode_finder(Calculation::OutputData &data){
 		
 // STEP 2:  perform first run with rough guesses 
 // STEP 2a: fill in all easy modes from simple guesses based on K
-		printf("\tinitial calculation of modes...\n");
+		ThrainLogger::info("\tinitial calculation of modes...\n");
 		for(auto kt=kl.begin(); kt!=kl.end(); kt++){
-			printf("\t\t%d,%d:\t", ltarget, *kt); fflush(stdout);
+			ThrainLogger::debug("\t\t%d,%d:\t", ltarget, *kt);
 			modetry = new MODE(*kt, ltarget, 0, data.driver);
-			printf("done\n");
+			ThrainLogger::debug("done\n");
 			mode::save_mode<MODE>(modetry, kfilled, w2filled, modefilled);
 		}
-		printf("\tdone");
+		ThrainLogger::info("\tdone\n");
 		std::size_t found=0, total=0;
 		for(auto kt=kl.begin(); kt!=kl.end(); kt++){
 			total++;
 			found += kfilled.count(*kt);
 		}
-		printf("found %lu/%lu!\n", found, total);
+		ThrainLogger::info("found %lu/%lu!\n", found, total);
 
 		// save values for the min,max values of K in list
 		int klo=*(kl.begin()), khi=*(kl.rbegin());
@@ -124,24 +124,24 @@ int mode_finder(Calculation::OutputData &data){
 
 		for(auto kt=kl.begin(); kt!=kl.end(); kt++){	
 			int ktarget = *kt;
-			printf("%d\tK=%d\t", ltarget, ktarget); fflush(stdout);
+			ThrainLogger::info("%d\tK=%d\t", ltarget, ktarget);
 
 // STEP 2b:  check if we have already been filled from earlier
 			if(kfilled.count(ktarget)){
 				//if we have then continue to next
-				printf("k=%d\talready found!\n", ktarget);
+				ThrainLogger::logInline(ThrainLogger::LogLevel::INFO, "k=%d\talready found!\n", ktarget);
 				continue;
 			}
 		
 // STEP 3: set brackets
 // STEP 3a: search within discovered modes to see if brackets exist	
-			printf("finding brackets.\n");
+			ThrainLogger::info("finding brackets.\n");
 			ktry = klo-1;
 			double w2min=0.0, w2max=0.0, dw2=0.0, w2in=0.0;
 			int kmax=klo-1, kmin=khi+1;
 			mode::get_min_from_set(kfilled, w2filled, ktarget, kmin, w2min);
 			mode::get_max_from_set(kfilled, w2filled, ktarget, kmax, w2max);
-			printf("\t\t(%d,%d) first fit\n", kmin, kmax);
+			ThrainLogger::info("\t\t(%d,%d) first fit\n", kmin, kmax);
 
 // STEP 3b: if one or both brackets do not exist, look for brackets
 			bool nomax = (kmax==klo-1), nomin = (kmin==khi+1); 
@@ -152,7 +152,7 @@ int mode_finder(Calculation::OutputData &data){
 				mode::save_mode<MODE>(modetry, kfilled, w2filled, modefilled);
 				//if this is the one we want, continue to next mode
 				if(kfilled.count(ktarget)){
-					printf("\tFOUND k=%d, w2=%lf\n", ktry,w2try);
+					ThrainLogger::info("\tFOUND k=%d, w2=%lf\n", ktry,w2try);
 					continue;
 				}
 // STEP 3c: if no min bracket, try to use current, or else use absolute min
@@ -189,7 +189,7 @@ int mode_finder(Calculation::OutputData &data){
 							modeMaxQuest = new MODE(w2max, ltarget, 0,data.driver);
 							kmax = modeMaxQuest->modeOrder();
 							w2max = modeMaxQuest->getOmega2();
-							printf("\t\t(%d,%d) in (%f,%f)\n",kmin, kmax, w2min, w2max);
+							ThrainLogger::info("\t\t(%d,%d) in (%f,%f)\n",kmin, kmax, w2min, w2max);
 							if( std::isnan(w2max) ) return 1;
 							// add this mode to discovered lists
 							mode::save_mode<MODE>(modeMaxQuest, kfilled, w2filled, modefilled);
@@ -199,11 +199,11 @@ int mode_finder(Calculation::OutputData &data){
 							}
 							// if we exceeded bounds, stop		
 							if(w2max > 1e6) {
-								printf("TOO LARGE\n");
+								ThrainLogger::info("TOO LARGE\n");
 								incr = 0.5;
 							}
 							if(w2max < 1e-6){
-								printf("No Dice\n");
+								ThrainLogger::info("No Dice\n");
 								break;
 							}
 							mode::get_max_from_set(kfilled, w2filled, ktarget, kmax, w2max);
@@ -215,10 +215,10 @@ int mode_finder(Calculation::OutputData &data){
 		
 // STEP 3c: if we could not find a max bracket, go on to next mode
 			if(kmax < ktarget){
-				printf("\t\tunable to find max bracket\n");
+				ThrainLogger::info("\t\tunable to find max bracket\n");
 				continue;
 			}
-			printf("\t\tbracketed (%d,%d) in (%f,%f)\n", kmin, kmax, w2min, w2max);
+			ThrainLogger::info("\t\tbracketed (%d,%d) in (%f,%f)\n", kmin, kmax, w2min, w2max);
 
 // STEP 4:  now we have brackets -- these SHOULD put bounds in frequency
 // for w2 in (w2min, w2max), will produce k in (kmin, kmax)
@@ -234,13 +234,13 @@ int mode_finder(Calculation::OutputData &data){
 				ktry = modetry->modeOrder();
 				w2try = modetry->getOmega2();
 				mode::save_mode<MODE>(modetry, kfilled, w2filled, modefilled);
-				printf("%d\t\t(%d,%d) in (%f,%f)\t %d\t %d %lf-->%lf\n",
+				ThrainLogger::info("%d\t\t(%d,%d) in (%f,%f)\t %d\t %d %lf-->%lf\n",
 						ltarget,kmin, kmax, w2min, w2max, *kt, ktry, w2in, w2try);
 
 //STEP 4c: compare the trial mode to desired mode
 //if we found it, move on to next
 				if(ktry==ktarget) {
-					printf("%d\tK=%d\tk=%d FOUND\n", ltarget, ktarget, ktry);
+					ThrainLogger::info("%d\tK=%d\tk=%d FOUND\n", ltarget, ktarget, ktry);
 					break;
 				}
 
@@ -261,7 +261,7 @@ int mode_finder(Calculation::OutputData &data){
 					modetry = new MODE(w2min, w2max, ltarget,0,data.driver);
 					ktry = modetry->modeOrder();
 					w2try = modetry->getOmega2();
-					printf("%d\t\t(%d,%d) in (%f,%f)\t %d\t %d %lf-->%lf\n",
+					ThrainLogger::info("%d\t\t(%d,%d) in (%f,%f)\t %d\t %d %lf-->%lf\n",
 						ltarget,kmin, kmax, w2min, w2max, *kt, ktry, w2in, w2try);
 					// add this to the lists
 					mode::save_mode<MODE>(modetry, kfilled, w2filled, modefilled);
@@ -280,7 +280,7 @@ int mode_finder(Calculation::OutputData &data){
 					ktry = modetry->modeOrder();
 					w2try = modetry->getOmega2();
 					mode::save_mode<MODE>(modetry, kfilled, w2filled, modefilled);
-					printf("\tR\t(%d,%d) in (%f,%f)\t %d\t %d %lf-->%lf\n",
+					ThrainLogger::info("\tR\t(%d,%d) in (%f,%f)\t %d\t %d %lf-->%lf\n",
 							kmin, kmax, w2minT, w2maxT, ktarget, ktry, w2in, w2try);
 					//check if we found mode, or if we can move brackets
 					if(ktry==ktarget) break;
@@ -313,13 +313,13 @@ int mode_finder(Calculation::OutputData &data){
 
 				// if we found it, say so
 				if(ktry == ktarget) {
-					printf("%d\tK=%d\tk=%d FOUND\n", ltarget, ktarget, ktry);
+					ThrainLogger::info("%d\tK=%d\tk=%d FOUND\n", ltarget, ktarget, ktry);
 					break;
 				}
 
 				//if we are just unable to find the mode, say so
 				if(ktry!=ktarget && fabs(w2max-w2min) < 1e-2*w2min){
-					printf("too close\t%le\n", fabs((w2max-w2min)/w2max) );
+					ThrainLogger::info("too close\t%le\n", fabs((w2max-w2min)/w2max) );
 					break;
 				}
 				
@@ -332,7 +332,7 @@ int mode_finder(Calculation::OutputData &data){
 // STEP 5: return through list to pick up any missed modes
 		// this calculation follows same steps as STEP 3 but because more
 		// modes have been filled, we are more likely to have good brackets
-		printf("L=%d\tpicking up stragglers...\n", ltarget);
+		ThrainLogger::info("L=%d\tpicking up stragglers...\n", ltarget);
 		for(auto kt= kl.begin(); kt!=kl.end(); kt++){
 			const int ktarget = *kt;
 			//STEP 5a:  check if we have already been filled from earlier
@@ -343,7 +343,7 @@ int mode_finder(Calculation::OutputData &data){
 			else {
 				//STEP 5b (i): find brackets to use in bisection by scanning list of modes
 				//  this pass through, we are more likely to have bracketing modes
-				printf("\t\t%d\t", *kt); fflush(stdout);
+				ThrainLogger::info("\t\t%d\t", *kt);
 				ktry = klo-1;
 				double w2min=0.0, w2max=0.0, dw2=0.0, w2in=0.0;
 				const int khi=*(kfilled.rbegin()), klo=*(kfilled.begin());
@@ -360,8 +360,8 @@ int mode_finder(Calculation::OutputData &data){
 					kmin = -1000000000;
 				}
 				//if we don't have a higher bound from calculated list, just leave
-				if(kmax > khi) { printf("no brackets\n"); continue;}
-				printf("(%d,%d)\t", kmin,kmax);fflush(stdout);
+				if(kmax > khi) { ThrainLogger::info("no brackets\n"); continue;}
+				ThrainLogger::info("(%d,%d)\t", kmin,kmax);
 				
 				//STEP 5b (ii): now bisect the brackets until correct mode is found
 				double prevmin=w2min, prevmax=w2max; //value of previous frequency
@@ -435,14 +435,14 @@ int mode_finder(Calculation::OutputData &data){
 					}
 				}
 				//if we found it, say so
-				if(kfilled.count(ktarget)) printf("found\n");
-				else printf("not found\n");
+				if(kfilled.count(ktarget)) ThrainLogger::info("found\n");
+				else ThrainLogger::info("not found\n");
 			}
 		}
-		printf("\tdone\n");
+		ThrainLogger::info("\tdone\n");
 
 //STEP 6: organize the data lists
-		printf("preparing output...\t"); fflush(stdout);
+		ThrainLogger::info("preparing output...\t");
 		int enext = data.mode_done;
 		for(auto kt=kl.begin(); kt!=kl.end(); kt++){
 			const int ktarget = *kt;
@@ -470,10 +470,10 @@ int mode_finder(Calculation::OutputData &data){
 			nextmode++;
 			data.mode_done++;
 		}
-		printf("done\n");
+		ThrainLogger::logInline(ThrainLogger::LogLevel::INFO, "done\n");
 	
 //STEP 7: calculate desired errors
-		printf("calculating errors...\t"); fflush(stdout);
+		ThrainLogger::info("calculating errors...\t");
 		int e=0;
 		//STEP 7a: for simple models, use RMSR to indicate numerical error
 		if(data.error[error::isRMSR]){
@@ -528,8 +528,8 @@ int mode_finder(Calculation::OutputData &data){
 			}
 			e++;
 		}
-		if(e!=data.i_err) printf("Error in mode error listing...\n");
-		printf("done\n");
+		if(e!=data.i_err) ThrainLogger::info("Error in mode error listing...\n");
+		ThrainLogger::logInline(ThrainLogger::LogLevel::INFO, "done\n");
 
 //STEP 8: at the end of each L, print all data to the output file 
 		io::write_mode_output(data);

--- a/src/ThrainStellar.cpp
+++ b/src/ThrainStellar.cpp
@@ -16,7 +16,7 @@ int create_classical_SWD(Calculation::OutputData &);
 
 //will select the correct creation fuction from above based on user input
 int create_star(Calculation::OutputData &data_out){
-	printf("Creating star...\n");
+	ThrainLogger::info("Creating star...\n");
 	switch(data_out.model) {
 		case model::polytrope:
 			create_classical_polytrope(data_out);
@@ -43,7 +43,7 @@ int create_classical_polytrope(Calculation::OutputData& data){
 
 	//calculate error estimate for this model
 	data.star_SSR = data.star->SSR();
-	printf("SSR = %le\n", data.star_SSR);
+	ThrainLogger::info("SSR = %le\n", data.star_SSR);
 	
 	return 0;
 }
@@ -74,7 +74,7 @@ int create_classical_CHWD(Calculation::OutputData& data){
 
 	//calculate error estimate for this model
 	data.star_SSR = data.star->SSR();
-	printf("SSR = %le\n", data.star_SSR);
+	ThrainLogger::info("SSR = %le\n", data.star_SSR);
 	
 	return 0;
 }
@@ -94,15 +94,15 @@ int create_classical_MESA(Calculation::OutputData& data){
 	
 	//calculate error estimate for this MESA model
 	data.star_SSR = data.star->SSR();
-	printf("SSR = %le\n", data.star_SSR);
+	ThrainLogger::info("SSR = %le\n", data.star_SSR);
 	
 	return 0;
 }
 
 //create a classical SimpleWD
 int create_classical_SWD(Calculation::OutputData& data){
-	printf("mass %lf\n", data.mass);
-	printf("teff %lf\n", data.teff);
+	ThrainLogger::info("mass %lf\n", data.mass);
+	ThrainLogger::info("teff %lf\n", data.teff);
 	data.star = new SimpleWD(
 		data.mass, 
 		data.teff,
@@ -119,7 +119,7 @@ int create_classical_SWD(Calculation::OutputData& data){
 
 	//calculate error estimate for this model
 	data.star_SSR = data.star->SSR();
-	printf("SSR = %le\n", data.star_SSR);
+	ThrainLogger::info("SSR = %le\n", data.star_SSR);
 	
 	return 0;
 }

--- a/src/ThrainUnits.cpp
+++ b/src/ThrainUnits.cpp
@@ -81,13 +81,13 @@ int format_units(Calculation::OutputData& data){
 			break;
 	}
 	
-	printf("\tmass=%lg\n", data.mass);
-	printf("\tradius=%lg\n", data.radius);
-	printf("\tzsurf=%lg\n\tlogg=%lg\n", data.zsurf, data.logg);
+	ThrainLogger::debug("\tmass=%lg\n", data.mass);
+	ThrainLogger::debug("\tradius=%lg\n", data.radius);
+	ThrainLogger::debug("\tzsurf=%lg\n\tlogg=%lg\n", data.zsurf, data.logg);
 	double mass_CGS = data.mass*data.unitset.base_mass;
 	double radius_CGS = data.radius*data.unitset.base_length;
 	data.freq0 = sqrt(G_CGS*mass_CGS*pow(radius_CGS,-3));
-	printf("\tfrequency scale = %lf\n", data.freq0);
+	ThrainLogger::debug("\tfrequency scale = %lf\n", data.freq0);
 	
 	return 0;
 }

--- a/src/constants.h
+++ b/src/constants.h
@@ -15,7 +15,7 @@
 #include "../lib/Splinor.h"
 #include "../lib/matrix.h"
 #include "../lib/string.h"
-// #include <time.h> //might use later to put a time stamp
+#include "../lib/logger.h"
 
 //constants and dependencies
 #ifndef CONSTANTS

--- a/tests/fullcalc_test.h
+++ b/tests/fullcalc_test.h
@@ -78,6 +78,7 @@ public:
     /* test uniform density (n=0) polytrope */
     void test_full_calculation_uniform() {
         printf("\nTEST CALCULATION UNIFORM STAR");
+        ThrainLogger::setLogLevel(ThrainLogger::LogLevel::ERROR);
         system("mkdir -p ./output/../tests/uniform/../tests");
         system("touch ./output/../tests/uniform/../tests/uniform.txt");
         Calculation::InputData in = make_input_data_pmodes("../tests/uniform");
@@ -96,6 +97,7 @@ public:
             }
             printf("\n");
         }
+        ThrainLogger::setLogLevel(ThrainLogger::LogLevel::INFO);
     }
 
 //     /* test n=1 polytrope */

--- a/tests/logger_test.h
+++ b/tests/logger_test.h
@@ -1,0 +1,224 @@
+// Tests of the logger
+
+#include "../src/constants.h"
+#include "../lib/string.h"
+#include <cxxtest/TestSuite.h>
+
+// define this for the tests below to work
+ThrainLogger::LogLevel operator+(ThrainLogger::LogLevel l, unsigned char i) {
+  unsigned char val = static_cast<unsigned char>(l);
+  return static_cast<ThrainLogger::LogLevel>(val + i);
+}
+
+namespace {
+  std::string const testfilename ("tests/tests/log_test.txt");
+}
+
+class LoggerTest : public CxxTest::TestSuite {
+public:
+
+static LoggerTest *createSuite (){
+  system( "mkdir -p tests/tests" );
+  printf("\n## LOGGER TESTS ##\n");
+  return new LoggerTest();
+}
+
+static void destroySuite(LoggerTest *suite) { 
+  printf("\n################");
+  remove(testfilename.c_str());
+  delete suite; 
+}
+
+void log_all_levels(ThrainLogger::LogLevel const level) {
+  // set the log level
+  ThrainLogger::setLogLevel(level);
+  // log at all levels
+  ThrainLogger::debug("%d\n", 1);
+  ThrainLogger::info("%d\n", 2);
+  ThrainLogger::warning("%d\n", 3);
+  ThrainLogger::error("%d\n", 4);
+}
+
+void log_func_all_levels(ThrainLogger::LogLevel const level) {
+  // redirect outout to file for checking
+  ThrainLogger::setOutputFile(testfilename, "w");
+  // set the log level
+  ThrainLogger::setLogLevel(level);
+  // log at all levels
+  for (auto l = ThrainLogger::LogLevel::DEBUG; l <= ThrainLogger::LogLevel::ERROR; l=l+1) {
+    ThrainLogger::log(l, "%d\n", static_cast<int>(l) + 1);
+  }
+  ThrainLogger::setLogLevel(level + 1);
+  // this will not be printed
+  ThrainLogger::log(level, "not printed");
+  ThrainLogger::unsetOutputFile();
+}
+
+void loginline_func_all_levels(ThrainLogger::LogLevel const level) {
+  // redirect outout to file for checking
+  ThrainLogger::setOutputFile(testfilename, "w");
+  // set the log level
+  ThrainLogger::setLogLevel(level);
+  // log at all levels
+  for (auto l = ThrainLogger::LogLevel::DEBUG; l <= ThrainLogger::LogLevel::ERROR; l=l+1) {
+    ThrainLogger::logInline(l, "%d", static_cast<int>(l) + 1);
+  }
+  ThrainLogger::setLogLevel(level + 1);
+  // this will not be printed
+  ThrainLogger::logInline(level, "not printed");
+  ThrainLogger::unsetOutputFile();
+}
+
+void check_logged_level(ThrainLogger::LogLevel const level) {
+  FILE *in = fopen(testfilename.c_str(), "r");
+  char line[128] = {'\0'};
+  int Y, M, D, h, m, s, res;
+  for (int i=static_cast<int>(level); i<=3; i++) {
+    fscanf(in, "%*4d-%*2d-%*2d %*2d:%*2d:%*2d [%*[A-Z]]: %d\n", &res);
+    TS_ASSERT_EQUALS(res, i + 1);
+  }
+  fgets(line, 120, in);
+  TS_ASSERT_EQUALS(line[0], '\0');
+}
+
+void check_file(char const *expected) {
+  FILE *in = fopen(testfilename.c_str(), "r");
+  char line[128] = {'\0'};
+  fgets(line, 128, in);
+  fclose(in);
+  TS_ASSERT_EQUALS(line, expected);
+}
+
+void test_set_output() {
+  ThrainLogger::setOutputFile(testfilename, "w");
+  char expected[] = "test";
+  ThrainLogger::logInline(ThrainLogger::LogLevel::INFO, expected);
+  ThrainLogger::unsetOutputFile();
+  ThrainLogger::logInline(ThrainLogger::LogLevel::INFO, "logged to stdout");
+  
+  // check output
+  check_file(expected);
+}
+
+// debug
+
+void test_debug() {
+  ThrainLogger::setOutputFile(testfilename, "w");
+  
+  log_all_levels(ThrainLogger::LogLevel::DEBUG);
+  // set the log level to info
+  ThrainLogger::setLogLevel(ThrainLogger::LogLevel::INFO);
+  // this will not be printed
+  ThrainLogger::debug("not printed");
+  ThrainLogger::unsetOutputFile();
+
+  check_logged_level(ThrainLogger::LogLevel::DEBUG);
+}
+
+void test_log_debug() {
+  log_func_all_levels(ThrainLogger::LogLevel::DEBUG);
+  check_logged_level(ThrainLogger::LogLevel::DEBUG);
+}
+
+void test_loginline_debug() {
+  loginline_func_all_levels(ThrainLogger::LogLevel::DEBUG);
+  check_file("1234");
+}
+
+// info
+
+void test_info() {
+  ThrainLogger::setOutputFile(testfilename, "w");
+  log_all_levels(ThrainLogger::LogLevel::INFO);
+  // set the log level to warning
+  ThrainLogger::setLogLevel(ThrainLogger::LogLevel::WARNING);
+  // this will not be printed
+  ThrainLogger::info("not printed");
+  ThrainLogger::unsetOutputFile();
+  check_logged_level(ThrainLogger::LogLevel::INFO);
+}
+
+void test_log_info() {
+  log_func_all_levels(ThrainLogger::LogLevel::INFO);
+  check_logged_level(ThrainLogger::LogLevel::INFO);
+}
+
+void test_loginline_info() {
+  loginline_func_all_levels(ThrainLogger::LogLevel::INFO);
+  check_file("234");
+}
+
+// warning
+
+void test_warning() {
+  ThrainLogger::setOutputFile(testfilename, "w");
+  
+  log_all_levels(ThrainLogger::LogLevel::WARNING);
+  // set the log level to error
+  ThrainLogger::setLogLevel(ThrainLogger::LogLevel::ERROR);
+  // this will not be printed
+  ThrainLogger::warning("not printed");
+  ThrainLogger::unsetOutputFile();
+
+  check_logged_level(ThrainLogger::LogLevel::WARNING);
+}
+
+void test_log_warning() {
+  log_func_all_levels(ThrainLogger::LogLevel::WARNING);
+  check_logged_level(ThrainLogger::LogLevel::WARNING);
+}
+
+void test_loginline_warning() {
+  loginline_func_all_levels(ThrainLogger::LogLevel::WARNING);
+  check_file("34");
+}
+
+// error
+
+void test_error() {
+  ThrainLogger::setOutputFile(testfilename, "w");
+  
+  log_all_levels(ThrainLogger::LogLevel::ERROR);
+  // set the log level to error
+  ThrainLogger::setLogLevel(ThrainLogger::LogLevel::MUTE);
+  // this will not be printed
+  ThrainLogger::error("not printed");
+  ThrainLogger::unsetOutputFile();
+
+  check_logged_level(ThrainLogger::LogLevel::ERROR);
+}
+
+void test_log_error() {
+  log_func_all_levels(ThrainLogger::LogLevel::ERROR);
+  check_logged_level(ThrainLogger::LogLevel::ERROR);
+}
+
+void test_loginline_error() {
+  loginline_func_all_levels(ThrainLogger::LogLevel::ERROR);
+  check_file("4");
+}
+
+// mute
+
+void test_mute() {
+  ThrainLogger::setOutputFile(testfilename, "w");
+  log_all_levels(ThrainLogger::LogLevel::MUTE);
+  ThrainLogger::unsetOutputFile();
+  check_file("");
+}
+
+void test_log_mute() {
+  ThrainLogger::setOutputFile(testfilename, "w");
+  log_func_all_levels(ThrainLogger::LogLevel::MUTE);
+  ThrainLogger::unsetOutputFile();
+  check_file("");
+}
+
+void test_loginline_mute() {
+  ThrainLogger::setOutputFile(testfilename, "w");
+  loginline_func_all_levels(ThrainLogger::LogLevel::MUTE);
+  ThrainLogger::unsetOutputFile();
+  check_file("");
+}
+
+};

--- a/tests/star_test.h
+++ b/tests/star_test.h
@@ -62,12 +62,12 @@ static void destroySuite(StarTest *suite) {
 }
 
 void setUp() {
-    freopen("tests/artifacts/startest_log.txt", "w", stdout);
-    printf("BEGIN STAR TESTS\n");
+    ThrainLogger::setOutputFile("tests/tests/startest_log.txt", "w");
+    ThrainLogger::info("BEGIN STAR TESTS\n");
 }
 
 void tearDown() {
-    freopen("/dev/tty", "w", stdout);
+    ThrainLogger::unsetOutputFile();
 }
 
 /***** basic tests of the SSR function *****/


### PR DESCRIPTION
`Thrain` previously had written all output directly to `stdout` using `printf`.  This made it hard to silence or redirect output.

This creates a simple logger with four levels, and updates the program to write with this instead `printf`.  Output is written almost identically to how `printf` works, including a format string with variadic arguments.

A set of comprehensive tests ensures the logger works as expected.

It is in principle possible to silence all output or to redirect it to a local file instead of the screen.  A future update should add that feature to the command line args.