### PR TITLE
Add non-zero surface term to fix homogeneous model $f$-modes

### DIFF
--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ ifeq ($(IS_MSVC),cl)
 	CXXFLAGS += /std:c++14 /W4 /EHsc
 else
 # GCC/Clang flags
-	CXXFLAGS += -std=c++14 -Wuninitialized -Weffc++ --pedantic-errors
+	CXXFLAGS += -std=c++14 -Wuninitialized -Weffc++ --pedantic-errors -Wno-unused-result
 endif
 
 # Auto dependency files

--- a/src/MODES/CowlingModeDriver.h
+++ b/src/MODES/CowlingModeDriver.h
@@ -18,6 +18,9 @@ public:
 	//constructor
 	//initialize from a background star and an adiabatic index
 	CowlingModeDriver(Star*, double);
+	//owns raw arrays; copying would double-free
+	CowlingModeDriver(CowlingModeDriver const&) = delete;
+	CowlingModeDriver& operator=(CowlingModeDriver const&) = delete;
 	//destructor
 	virtual ~CowlingModeDriver();
 	
@@ -28,19 +31,19 @@ public:
 	void getCoeff(double *CC, const std::size_t, const int, const double, const int) override final;
 
 private:
-	std::size_t len;		//number of grid points for mode
-	std::size_t len_star;	//number of grid points in star
+	std::size_t len = 0;		//number of grid points for mode
+	std::size_t len_star = 0;	//number of grid points in star
 	double adiabatic_index;	//adiabatic index; set to 0 to use star's Gamma1
 	enum VarNames {y1=0, y2};
-	
+
 	//perturbation quantities
-	double *r, *A, *U, *C, *V;
+	double *r = nullptr, *A = nullptr, *U = nullptr, *C = nullptr, *V = nullptr;
 	void initializeArrays();
 	
 	static const int BC_C = 4;	//the desired order near the center
 	static const int BC_S = 4;	//the desired order near the surface
 	//expansion coefficients near surface;
-	double As[BC_S+1], Vs[BC_S+1], cs[BC_S+1], Us[BC_S+1], cProds[BC_S+1], k_surface;
+	double As[BC_S+1], Vs[BC_S+1], cs[BC_S+1], Us[BC_S+1], cProds[BC_S+1], k_surface = 0.0;
 	//expansion coefficients near center;
 	double Ac[BC_C/2+1], Vc[BC_C/2+1], cc[BC_C/2+1], Uc[BC_C/2+1], cProdc[BC_C/2+1];
 	void setupBoundaries() override final;

--- a/src/MODES/NonradialModeDriver.cpp
+++ b/src/MODES/NonradialModeDriver.cpp
@@ -224,7 +224,7 @@ std::size_t NonradialModeDriver::SurfaceBC(double **ymode, double *ys, double om
 	yy[y1][0] = ys[y1];
 	yy[y2][0] = ys[y1] + ys[y3];
 	yy[y3][0] = ys[y3];
-	yy[y4][0] = -double(l+1)*ys[y3];
+	yy[y4][0] = -double(l+1)*ys[y3] - Us[0]*ys[y1];
 	
 	//constants that show up
 	double L2 = double(l*l+l);

--- a/src/MODES/NonradialModeDriver.h
+++ b/src/MODES/NonradialModeDriver.h
@@ -20,6 +20,9 @@ public:
 	//constructor
 	//initialize from a background star and an adiabatic index
 	NonradialModeDriver(Star*, double);
+	//owns raw arrays; copying would double-free
+	NonradialModeDriver(NonradialModeDriver const&) = delete;
+	NonradialModeDriver& operator=(NonradialModeDriver const&) = delete;
 	//destructor
 	virtual ~NonradialModeDriver();
 
@@ -30,20 +33,18 @@ public:
 	void getCoeff(double *CC, const std::size_t, const int, const double, const int) override final;
 
 private:
-	std::size_t len;		//number of grid points for mode
-	std::size_t len_star;	//number of grid points in star
+	std::size_t len = 0;		//number of grid points for mode
+	std::size_t len_star = 0;	//number of grid points in star
 	double adiabatic_index;	//adiabatic index; set to 0 to use star's Gamma1
 	enum VarNames {y1=0, y2, y3, y4};
-	
-	
 	//perturbation quantities that appear in Dziembowski equations
-	double *r, *A, *U, *C, *V;
+	double *r = nullptr, *A = nullptr, *U = nullptr, *C = nullptr, *V = nullptr;
 	void initializeArrays();
 	
 	static const std::size_t BC_C = 4;	//the desired order near the center
 	static const std::size_t BC_S = 4;	//the desired order near the surface
 	//expansion coefficients near surface;
-	double As[BC_S+1], Vs[BC_S+1], cs[BC_S+1], Us[BC_S+1], cProds[BC_S+1], k_surface;
+	double As[BC_S+1], Vs[BC_S+1], cs[BC_S+1], Us[BC_S+1], cProds[BC_S+1], k_surface = 0.0;
 	//expansion coefficients near center;
 	double Ac[BC_C/2+1], Vc[BC_C/2+1], cc[BC_C/2+1], Uc[BC_C/2+1], cProdc[BC_C/2+1];
 	void setupBoundaries() override final;

--- a/src/STARS/Polytrope.h
+++ b/src/STARS/Polytrope.h
@@ -29,6 +29,9 @@ public:
 	Polytrope(double, double, double, std::size_t);	//constructor, M, R, n and length
 	Polytrope(double, std::size_t);					//constructor, n and length
 	Polytrope(double, std::size_t, const double);	//constructor, n and length, dx
+	//owns raw arrays; copying would double-free
+	Polytrope(Polytrope const&) = delete;
+	Polytrope& operator=(Polytrope const&) = delete;
 	virtual ~Polytrope();  //destructor
 	std::size_t length() override final {return len;}
 	//these three functions specify units
@@ -73,14 +76,14 @@ private:
 	//to rescale, basically "finish" the part of Rn we left off, sqrt[Pc/(Grho^2)]
 	// radius scales like finished Rn
 	// mass scales like rho0*Rn3
-	double rho0;	//central density
-	double P0;		//central pressure
-	double Rn;		//radius scale factor
+	double rho0 = 0.0;	//central density
+	double P0 = 0.0;	//central pressure
+	double Rn = 0.0;	//radius scale factor
 	//lane-emden solution functions
 	enum VarName {x=0, y, z, numvar};
-	double **Y;   //at each point X, variables x, y, z
-	double *mass;
-	double *base; //= pow(y,n-1), avoids repeated calls to pow(y,n)
+	double **Y = nullptr;   //at each point X, variables x, y, z
+	double *mass = nullptr;
+	double *base = nullptr; //= pow(y,n-1), avoids repeated calls to pow(y,n)
 	double GG;
 	double set_mass(double const y[numvar]);
 		

--- a/src/ThrainMode.cpp
+++ b/src/ThrainMode.cpp
@@ -109,10 +109,9 @@ double calculate_Pekeris(int l, int k, double Gam1){
 	double wPek2, dnl;
 	if(k<0) wPek2 = 0.0;
 	else if(k==0) {
-		//there is a formula for f-modes due to Chandrasekhar (1964, ApJ vol 139 p 664), 
+		//there is a formula for f-modes due to Chandrasekhar (1964, ApJ vol 139 p 664),
 		// c.f. Cox (1980) eq 17.80
-		// NOTE the values I get are always wPek2 = l
-		wPek2 = double(l); //double(2.*l*(l-1))/double(2*l+1);
+		wPek2 = double(2*l*(l-1))/double(2*l+1);
 	}
 	else {
 		// for modes in uniform stars, compare to the exact equation of Pekeris 1938, eq 32

--- a/tests/fullcalc_test.cpp
+++ b/tests/fullcalc_test.cpp
@@ -111,13 +111,9 @@ TEST_CASE_FIXTURE(SetUpTearDown, "full_calculation_uniform [slow]") {
 
   CHECK_LT(out.star_SSR, 1.e-12);
   for(int i=0; i<out.mode_num; i++){
-    printf("%d,%d\t", out.l[i], out.k[i]);
-    if(out.k[i]!=0){
-      printf("%le %le", out.err[0][i], out.err[1][i]);
-      CHECK_LT(out.err[0][i], 1.e-8);
-      CHECK_LT(out.err[1][i], 1.e-6);
-    }
-    printf("\n");
+    printf("%d,%d\t%le %le\n", out.l[i], out.k[i], out.err[0][i], out.err[1][i]);
+    CHECK_LT(out.err[0][i], 1.e-8);
+    CHECK_LT(out.err[1][i], 1.e-6);
   }
   // cleanup
   ThrainLogger::setLogLevel(ThrainLogger::LogLevel::INFO);

--- a/tests/mode_test.cpp
+++ b/tests/mode_test.cpp
@@ -310,10 +310,13 @@ TEST_CASE("same_coefficients_star") {
 
 TEST_CASE("same_on_dummy_star") {
     /*
-    It can be shown that for the DummyStar with P=rho=const, 
-    that there is only a single mode per L,
-    that this mode has a frequency of sqrt(L),
-    and that it is the same in both Cowling and 4th-order wave forms.
+    It can be shown that for the DummyStar with P=rho=const,
+    that there is only a single mode per L.
+    In the Cowling approximation this mode has a frequency of sqrt(L).
+    In the 4th-order wave form, U=3 at the surface sources a potential
+    perturbation from the surface distortion, lowering the frequency to
+    the Kelvin value 2L(L-1)/(2L+1); for L=1 this is zero (a neutral
+    translation), which the mode search cannot converge to.
     */
     double const MACHINE_PRECISION = 1.e-15;
     std::size_t const LEN (1001);
@@ -324,10 +327,13 @@ TEST_CASE("same_on_dummy_star") {
 
     // create a Cowling mode and Nonradial mode on the same star
     for (int L=1; L<10; L++){
-        auto nonradialMode = std::make_unique<Mode<4UL>>(0, L, 0, nonradialDriver.get());
         auto cowlingMode   = std::make_unique<Mode<2UL>>(0, L, 0, cowlingDriver.get());
-        CHECK_DELTA( cowlingMode->getOmega2(), nonradialMode->getOmega2(), MACHINE_PRECISION );
         CHECK_DELTA( cowlingMode->getOmega2(), double(L), MACHINE_PRECISION );
+    }
+    double const KELVIN_PRECISION = 1.e-12;
+    for (int L=2; L<10; L++){
+        auto nonradialMode = std::make_unique<Mode<4UL>>(0, L, 0, nonradialDriver.get());
+        CHECK_DELTA( nonradialMode->getOmega2(), double(2*L*(L-1))/double(2*L+1), KELVIN_PRECISION );
     }
 }
 

--- a/tests/thrainmode_test.cpp
+++ b/tests/thrainmode_test.cpp
@@ -52,7 +52,7 @@ TEST_SUITE("Mode Base Tests") {
     // first trst special case for K=0
     int K = 0;
     for(int L=2; L<10; L++){
-      double exp = sqrt(L); //sqrt(double(2*L*(L-1))/double(2*L+1));
+      double exp = sqrt(double(2*L*(L-1))/double(2*L+1));
       double res = mode::compare_Pekeris(exp, L, K, 0.0);
       CHECK_LT(res, 1.0e-12);
     }


### PR DESCRIPTION
The uniform density (aka isopycnic) star model of Thrain was used model as a calibration tool, for comparing to the exact Pekeris solutions.  However, it had a known flaw, that it consistently produced the wrong value for the $f$-mode.  See Issue #16 .

This problem is due to the non-vanishing surface density of the uniform density model.  Unlike real stars, and even polytropes, the uniform density star's density does not taper to zero at the surface, but actually has a sharp $\Theta$-function cutoff.

To account for this, Unno et al. mention the possible surface term.  It can be seen from the perturbed gravitationl field equation,
$\frac{1}{r^2}\frac{d}{dr} \big(r^2 \frac{d\Delta\Phi}{dr}\big) - \frac{\ell(\ell+1)}{r^2}\Delta\Phi = 4\pi G\Delta\rho.$$
For most starts, $\Delta\rho \rightarrow 0$ at the  surface.  For the uniform density model, it becomes 
$$\Delta\rho = \rho_o \delta(R-r) \xi^r,$$
and integrating
$$r\frac{d\Delta\Phi}{dr} = -(\ell+1) \Delta\Phi + 4\pi G \rho_o \xi^r r$$

In Dziembowski variables, this term becomes
$$y_4 = -(\ell+1) y_3 - Uy_1.$$

Since for all non-uniform stars this final term is zero, we can add this extra term, which will appear only in the case of a star with a surface term.

Now, we get the correct value for the uniform star $f$-mode.  Also makes some changes to reduce the compiler warnings.

Closes #16