### PR TITLE
Fix warnings

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -133,7 +133,6 @@ jobs:
       run: pixi run thrain sampleinput6.txt
 
     - name: Build THRAIN tests
-      if: startsWith(matrix.config.os, 'ubuntu') || startsWith(matrix.config.os, 'macos')
       shell: bash
       env:
         CC: ${{ matrix.config.cc }}

--- a/lib/rootfind.hxx
+++ b/lib/rootfind.hxx
@@ -39,6 +39,11 @@ T rootfind::newton_search(
 
 	while(std::abs(target-f1)>tol && tracker++!=max_iter){
 		f2 = func(x+dx);
+		if(f2==f1){
+			//the function is locally flat, so no Newton step can be taken
+			ThrainLogger::error("ERROR: Newton search stuck on flat region!\n");
+			break;
+		}
 		ddx = dx*(target-f1)/(f2-f1);
 		x += ddx;
 		dx = ddx;
@@ -62,9 +67,11 @@ void rootfind::newton_search(
 	double F1=0.0, F2=0.0, maxDF = -1.0;
 	for(int i=0; i<np; i++) F1 += 0.5*f1[i]*f1[i];
 	
-	for(int i=0; i<np; i++) ddx[i] = dx[i];
 	for(int i=0; i<np; i++) maxDF = fmax(maxDF, std::abs(f1[i]));
 	while( maxDF > tol && tracker++!=max_iter){
+		//probe with small steps relative to the current position, so that the
+		//  probes remain within the trust region; fall back on caller dx at zero
+		for(int i=0; i<np; i++) ddx[i] = (x1[i] != 0.0 ? 0.01*x1[i] : dx[i]);
 		//calculate the matrix of derivatives (df/dx)
 		for(int i=0; i<np; i++) x2[i] = x1[i];
 		for(int i=0; i<np; i++) {
@@ -83,6 +90,14 @@ void rootfind::newton_search(
 			// then do something to try to recover
 			ThrainLogger::error("ERROR: Matrix inversion failed!\nTrying to recover with past value.\n");
 			//use the last gradient
+			double scale = rootfind::pseudo_unif();
+			for(int i=0; i<np; i++) dx[i] = scale*dxsave[i];
+		}
+		//if inversion produced NaNs (e.g. NaN residuals), also recover with past value
+		bool anyNaN = false;
+		for(int i=0; i<np; i++) anyNaN |= std::isnan(dx[i]);
+		if(anyNaN){
+			ThrainLogger::error("ERROR: Newton step is NaN!\nTrying to recover with past value.\n");
 			double scale = rootfind::pseudo_unif();
 			for(int i=0; i<np; i++) dx[i] = scale*dxsave[i];
 		}
@@ -111,14 +126,7 @@ void rootfind::newton_search(
 		F1 = F2;
 		for(int i=0; i<np; i++) f1[i] = f2[i];
 		for(int i=0; i<np; i++) x1[i] = x2[i];
-		
-		//if none of the dx are zero, use these as the new differences in numerical differentiation
-		bool anyZero = false;
-		for(int i=0; i<np; i++) anyZero |= (dx[i]==0.0);
-		if(!anyZero){
-			for(int i=0; i<np; i++) ddx[i] = dx[i];
-		}
-		
+
 		//determine the max difference
 		maxDF = -1.0;
 		for(int i=0; i<np; i++) if(fabs(f1[i])>maxDF) maxDF = fabs(f1[i]);
@@ -136,12 +144,12 @@ void rootfind::newton_search(
 	std::function<bool(double[np])> const& var_limit //a function limiting values of x1
 ){
 	// make a new function with zero at the target
-	std::function<void(double f[np], double x[np])>& zero_func = [func,target](double f[np], double x[np]){
+	std::function<void(double f[np], double x[np])> const zero_func = [&func,&target](double f[np], double x[np]){
 		func(f,x);
 		for(std::size_t i=0; i<np; i++){
 			f[i] = target[i] - f[i];
 		}
 	};
-	rootfind::newton_search(zero_func, x1, dx, tol, max_iter);
+	rootfind::newton_search<np>(zero_func, x1, dx, tol, max_iter, var_limit);
 }
 #endif

--- a/lib/stellar.h
+++ b/lib/stellar.h
@@ -60,9 +60,10 @@ struct Abundance {
 	Abundance operator-(const Abundance& x){
 		return Abundance(H1-x.H1, He4-x.He4, C12-x.C12, O16-x.O16);
 	}
-	void operator=(const Abundance& x){
+	Abundance& operator=(const Abundance& x){
 		H1 = x.H1; He4 = x.He4; C12 = x.C12; O16 = x.O16;
 		e = x.e;
+		return *this;
 	}
 	double  operator[](int n) const {
 		switch(n){
@@ -214,7 +215,7 @@ public:
 	void push_back(PartialPressure);
 private:
 	//the partial pressures are stored as function pointers in a vector object
-	std::vector<PartialPressure> pressure;
+	std::vector<PartialPressure> pressure {};
 };
 
 //************************************************************************************

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ ifeq ($(IS_MSVC),cl)
 	CXXFLAGS += /std:c++14 /W4 /EHsc
 else
 # GCC/Clang flags
-	CXXFLAGS += -std=c++14 -Wuninitialized -Weffc++ --pedantic-errors -Wno-unused-result
+	CXXFLAGS += -std=c++14 -Wuninitialized -Weffc++ --pedantic-errors -Wno-unused-result -Werror
 endif
 
 # Auto dependency files

--- a/src/MODES/Mode.h
+++ b/src/MODES/Mode.h
@@ -29,6 +29,9 @@ public:
 	Mode<numvar>(double omega2, int l, int m, ModeDriver*);
 	//initialize from brackets on frequency and a background star
 	Mode<numvar>(double omegMin, double omegMax, int l, int m, ModeDriver*);
+	//owns raw arrays; copying would double-free
+	Mode<numvar>(Mode<numvar> const&) = delete;
+	Mode<numvar>& operator=(Mode<numvar> const&) = delete;
 	//deconstructor
 	virtual ~Mode();
 	
@@ -50,23 +53,23 @@ protected:
 	//the mode driver specifying equations and boundaries
 	ModeDriver *const driver;
 	void basic_setup();	//handles the normal setup common to all constructors
-	int k,l,m;			//the mode numbers
-	double cee2, Gee;	//for specifying units
-	double Gamma1;		//adiabatic exponent for perturbations	
-	std::size_t len, len_star;	//length of mode arrays, and length of background model arrays
-	double omega2;		//frequency squared
-	double *rad;		//the radial coordinate, x = r/R
+	int k = 0,l,m;		//the mode numbers
+	double cee2 = 0.0, Gee = 0.0;	//for specifying units
+	double Gamma1 = 0.0;//adiabatic exponent for perturbations
+	std::size_t len = 0, len_star = 0;	//length of mode arrays, and length of background model arrays
+	double omega2 = 0.0;//frequency squared
+	double *rad = nullptr;	//the radial coordinate, x = r/R
 	//perturbation quantities
-	double **y;			//the eigenfunctions y_1, y_2, ..., y_N
+	double **y = nullptr;	//the eigenfunctions y_1, y_2, ..., y_N
 	double yCenter[numvar], ySurface[numvar];//central and surface values of y_1,...y_N
-	
-	bool converged;		//a flag for indicating if calculation converged -- no longer needed
+
+	bool converged = false;	//a flag for indicating if calculation converged -- no longer needed
 	void convergeBisect(double);		//find frequency using a bisection search
 	void convergeNewton(double, int);	//find frequency using a Newton method
 
 	double calculateWronskian(double w2);
 	void linearMatch(double w2, double y0[numvar], double ys[numvar]);
-	std::function<double(double)> wronskian;
+	std::function<double(double)> wronskian {};
 	int verifyMode();
 	void converge();
 	//
@@ -77,9 +80,9 @@ protected:
 	double boundaryMatrix[numvar][numvar]; //the BCs specified in matrix form
 	int    indexOrder[numvar];             //the order in which to multipy factors to match
 	
-	std::size_t xfit;    //the coordinate where inner/outer solutions are fit
-	double omeg2freq;    //converstion from dimensionless frequency to angular frequency
-	double R;            //the radius of the star
+	std::size_t xfit = 0;    //the coordinate where inner/outer solutions are fit
+	double omeg2freq = 0.0;  //converstion from dimensionless frequency to angular frequency
+	double R = 0.0;          //the radius of the star
 
 public:
 	//file output methods to write and view plots of mode

--- a/src/STARS/ChandrasekharWD++.h
+++ b/src/STARS/ChandrasekharWD++.h
@@ -35,6 +35,9 @@ public:
 	ChandrasekharWD(double, std::size_t,               ChemicalGrad);
 	ChandrasekharWD(double, std::size_t, const double, ChemicalGrad);
 	ChandrasekharWD(double, std::size_t, double const A0, double const B0);
+	//owns raw arrays; copying would double-free
+	ChandrasekharWD(ChandrasekharWD const&) = delete;
+	ChandrasekharWD& operator=(ChandrasekharWD const&) = delete;
 
 	virtual ~ChandrasekharWD();   //destructor
 	std::size_t length() override final {return len;}
@@ -67,8 +70,8 @@ private:
 	void init_arrays();
 	std::size_t len;
 	double Y0;		// central value of y, y^2=1+x^2
-	double X0, X02, Y02;
-	double Rn;		// radius scale
+	double X0 = 0.0, X02 = 0.0, Y02 = 0.0;
+	double Rn = 0.0;	// radius scale
 	double A0, B0;  // pressure and density scales
 	//lane-emden solution functions
 	// @xi	normalized radius
@@ -77,17 +80,17 @@ private:
 	// @z   derivative (dy/dxi)  note: dx/dxi = (dy/dxi)/x
 	// @f   the factor f(X)
 	enum VarName {xi=0, y, z, x, f, numvar};
-	double **Y;
-	double *mass;
-	double *x3; // holds x^3, to avoid repeated calls to pow
+	double **Y = nullptr;
+	double *mass = nullptr;
+	double *x3 = nullptr; // holds x^3, to avoid repeated calls to pow
 	double set_mass(double const y[numvar], double const x);
 		
 	// the chemical profile
 	ChemicalGrad chemical_gradient;
 
 	//to handle chemical profile
-	double* mue;   //mean atomic mass per electron
-	double* dmue;  //derivative of above
+	double* mue = nullptr;   //mean atomic mass per electron
+	double* dmue = nullptr;  //derivative of above
 
 	//integrate using basic RK4
 	void centerInit(double ycenter[numvar]);

--- a/src/STARS/MESA.cpp
+++ b/src/STARS/MESA.cpp
@@ -40,7 +40,7 @@ MESA::MESA(std::string const &filename, std::size_t L) : len(L) {
 	for(std::size_t k=0; k<Ntot-1; k++){
 		fscanf(infile, "%*[^\n]\n");
 	}
-	fscanf(infile, "%*d %lg %lg %lg %*lg %lg %*lg %lg %*[^\n]", &Rtot, &Mtot, &Ltot, ts, &dels);
+	fscanf(infile, "%*d %lg %lg %lg %*g %lg %*g %lg %*[^\n]", &Rtot, &Mtot, &Ltot, ts, &dels);
 
 	//set scale quantities
 	Dscale = Mtot*pow(Rtot,-3)/(4.*m_pi);
@@ -59,8 +59,8 @@ MESA::MESA(std::string const &filename, std::size_t L) : len(L) {
 	//read from the file
 	fseek(infile, firstdata, SEEK_SET);
 	for(std::size_t k=0; k<Ntot; k++){
-		fscanf(infile, " %*d %lg  %lg  %*lg", &rt[k], &mt[k]);
-		fscanf(infile, " %lg %*lg %lg  %*lg", &pt[k], &dt[k]);
+		fscanf(infile, " %*d %lg  %lg  %*g", &rt[k], &mt[k]);
+		fscanf(infile, " %lg %*g %lg  %*g", &pt[k], &dt[k]);
 		fscanf(infile, " %lg %lg           ", &Nt[k], &Gt[k]);
 		fscanf(infile, " %*[^\n]\n");
 		//dis-dimensionalize the variables

--- a/src/STARS/MESA.h
+++ b/src/STARS/MESA.h
@@ -15,6 +15,9 @@
 class MESA : public Star {
 public:	
 	MESA(std::string const&, std::size_t);	//constructor
+	//owns raw arrays and Splinors; copying would double-free
+	MESA(MESA const&) = delete;
+	MESA& operator=(MESA const&) = delete;
 	virtual ~MESA(); //destructor - clears all space in memory
 	std::size_t length() override final {return len;}
 	double Mass() override final;
@@ -44,23 +47,23 @@ public:
 	double sound_speed2(std::size_t, double GamPert=0) override final;
 
 private:
-	std::size_t Ntot, len, subgrid;  //Ntot = grid size from MESA
+	std::size_t Ntot = 0, len, subgrid = 0;  //Ntot = grid size from MESA
 	//in units of g, cm, erg/s, respectively
-	double Mtot, Rtot, Ltot;
-	double Mstar, Rstar, Lstar;
-	double Dscale, Pscale, Gscale;
+	double Mtot = 0.0, Rtot = 0.0, Ltot = 0.0;
+	double Mstar = 0.0, Rstar = 0.0, Lstar = 0.0;
+	double Dscale = 0.0, Pscale = 0.0, Gscale = 0.0;
 	//arrays for density, pressure, mass, and gravitational field
-	double *radi;	
-	Splinor *dens, *pres, *mass, *grav, *Gam1, *BVfq;
-	Splinor *aSpline, *vSpline, *uSpline, *cSpline;
-	
+	double *radi = nullptr;
+	Splinor *dens = nullptr, *pres = nullptr, *mass = nullptr, *grav = nullptr, *Gam1 = nullptr, *BVfq = nullptr;
+	Splinor *aSpline = nullptr, *vSpline = nullptr, *uSpline = nullptr, *cSpline = nullptr;
+
 	//for BCs of modes
-	double nc;// effective polytropic index at center
+	double nc = 0.0;// effective polytropic index at center
 	double ac[8]; //coefficients of theta near center
 	double dc[3],pc[3];
 	double A0[3],V0[3],c0[3],U0[3];
 	//surface
-	double ds[5], ps[5], ts[5], dels;
+	double ds[5], ps[5], ts[5], dels = 0.0;
 	double A1[5], V1[5], c1[5], U1[5];
 	
 	void setupCenter();

--- a/src/STARS/SimpleWD.h
+++ b/src/STARS/SimpleWD.h
@@ -81,9 +81,9 @@ private:
 	double Dscale = 0.0, Pscale = 0.0, Tscale = 0.0;
 
 	//solution functions
-	double *logQ;	   // the independent variable
-	StellarVar*  logY; // log density, radius, pressure, mass, temperature, luminosity
-	StellarVar* dlogY; // dlogY/dlogQ, as above
+	double *logQ = nullptr;	   // the independent variable
+	StellarVar*  logY = nullptr; // log density, radius, pressure, mass, temperature, luminosity
+	StellarVar* dlogY = nullptr; // dlogY/dlogQ, as above
 	void setupGrid(double, std::size_t);
 	void expandGrid(std::size_t);
 
@@ -111,7 +111,7 @@ private:
 	
 	//abundances
 	Abundance  Xtot {};
-	Abundance *Xelem, *dXelem;
+	Abundance *Xelem = nullptr, *dXelem = nullptr;
 	Abundance massFraction();
 	//
 	EOS core_pressure {}, atm_pressure {};
@@ -123,7 +123,7 @@ private:
 	Abundance findAbundance(const double, const double, Abundance&);
 	
 	//thermodynamic variables
-	double *adiabatic_1, *nabla, *nabla_ad, *brunt_vaisala, *ledoux, *kappa;
+	double *adiabatic_1 = nullptr, *nabla = nullptr, *nabla_ad = nullptr, *brunt_vaisala = nullptr, *ledoux = nullptr, *kappa = nullptr;
 	void populateBruntVaisala();
 
 	//methods for handling the BCs

--- a/src/STARS/SimpleWD.h
+++ b/src/STARS/SimpleWD.h
@@ -60,6 +60,11 @@ public:
 	Abundance Xmass;
 		
 private:
+
+	// delete copy and assignment
+	SimpleWD(SimpleWD const&) = delete;
+	SimpleWD& operator=(SimpleWD const&) = delete;
+
 	void setup();
 	void initFromChandrasekhar();
 	StellarVar Ystart0, YstartS;

--- a/src/STARS/SimpleWD.h
+++ b/src/STARS/SimpleWD.h
@@ -57,30 +57,28 @@ public:
 	double sound_speed2(std::size_t, double GamPert=0.0) override;
 	double Ledoux(std::size_t, double GamPert=0.0);
 	double BruntVaisala(std::size_t, double GamPert=0.0);
-	Abundance Xmass;
+	Abundance Xmass {};
 		
 private:
-
 	// delete copy and assignment
 	SimpleWD(SimpleWD const&) = delete;
 	SimpleWD& operator=(SimpleWD const&) = delete;
 
 	void setup();
 	void initFromChandrasekhar();
-	StellarVar Ystart0, YstartS;
-	double Y0; //the value y0 from the Chandrasekhar model
+	StellarVar Ystart0 {}, YstartS {};
+	double Y0 = 0.0; //the value y0 from the Chandrasekhar model
 	void rescaleR();
 
+	std::size_t Ntot, Ncore = 0, Natm = 0;//number of grid points
 
-	std::size_t Ntot, Ncore, Natm;//number of grid points
-	
 	//surfce values
-	double Msolar, Mstar; //in solar and CGS units
-	double Lsolar, Lstar; //in solar and CGS units
-	double Rsolar, Rstar; //in solar and CGS units
+	double Msolar, Mstar = 0.0; //in solar and CGS units
+	double Lsolar = 0.0, Lstar = 0.0; //in solar and CGS units
+	double Rsolar = 0.0, Rstar = 0.0; //in solar and CGS units
 	double Teff;		  //effective temperature (K)
 	//scale values
-	double Dscale, Pscale, Tscale;
+	double Dscale = 0.0, Pscale = 0.0, Tscale = 0.0;
 
 	//solution functions
 	double *logQ;	   // the independent variable
@@ -89,12 +87,12 @@ private:
 	void setupGrid(double, std::size_t);
 	void expandGrid(std::size_t);
 
-	StellarVar Yscale, logYscale;
-	StellarVar Ysolar;
-	StellarVar Ystar;
+	StellarVar Yscale {}, logYscale {};
+	StellarVar Ysolar {};
+	StellarVar Ystar {};
 	
 	//methods to calculate the two regions
-	static const int numv=3;
+	static constexpr std::size_t numv = 3;
 	void        joinAtCenter(double x[numv], double f[numv], double& F);
 	double      calculateCore( const double x[numv], std::size_t Nmax);
 	std::size_t firstCoreStep( const double x[numv], double& rholast, std::size_t Nmax);
@@ -112,24 +110,24 @@ private:
 	double energyTransport( const StellarVar&, const Abundance&);
 	
 	//abundances
-	Abundance  Xtot;
+	Abundance  Xtot {};
 	Abundance *Xelem, *dXelem;
 	Abundance massFraction();
 	//
-	EOS core_pressure, atm_pressure;
+	EOS core_pressure {}, atm_pressure {};
 	EOS* getEOS(const StellarVar& Y, const Abundance& X);
-	
-	double zy, zc, zo;
-	double by, bc, bo;
-	double my, mc, mo;
+
+	double zy = 0.0, zc = 0.0, zo = 0.0;
+	double by = 0.0, bc = 0.0, bo = 0.0;
+	double my = 0.0, mc = 0.0, mo = 0.0;
 	Abundance findAbundance(const double, const double, Abundance&);
 	
 	//thermodynamic variables
 	double *adiabatic_1, *nabla, *nabla_ad, *brunt_vaisala, *ledoux, *kappa;
 	void populateBruntVaisala();
-		
+
 	//methods for handling the BCs
-	double nc;
+	double nc = 0.0;
 	double ac[8];
 	double tc[4], dc[4], pc[4];
 	double A0[4], V0[4], c0[4], U0[4];

--- a/src/ThrainMain.h
+++ b/src/ThrainMain.h
@@ -37,47 +37,47 @@ namespace error {enum ErrorType {isRMSR=0, isC0, isIsopycnic, isJCD, numerror};}
 //an  object specifying input parameters for a calculation
 namespace Calculation{
 struct InputData {
-	std::string calcname;            //unique user-chosen identifier for calculation
-	regime::Regime regime;           //the regime of physics to use: Newtonian, 1PN, GR
-	model::StellarModel model;       //the model of star to use in calculations
-	units::Units units;              //the choice of units, eg: CGS, SI, astronomical, ...
-	modetype::ModeType modetype;     //the kind of modes to calculation: Cowling, 4th order, ...
-	std::vector<double> input_params;//parameters needed for the stellar model calculation
-	std::string str_input_param;     //a possible string parameter, such as a file name
-	std::size_t mode_num;            //the number of modes to be calculated
-	std::size_t Ngrid;               //the number of grid points to use in the calculation
-	std::set<int> l;                 //the set of L in calculation
-	std::map<int,std::set<int>> kl;  //for each L, the set of K to search
-	double mass, radius, zsurf, logg, teff;//properties of a star
-	char params;                     //records which of the above properties was specified
-	double adiabatic_index;          //an adiabatic index to use in oscillations; if 0 uses natural Gamma
+	std::string calcname {};         //unique user-chosen identifier for calculation
+	regime::Regime regime = regime::PN0;             //the regime of physics to use: Newtonian, 1PN, GR
+	model::StellarModel model = model::polytrope;    //the model of star to use in calculations
+	units::Units units = units::Units::astro;        //the choice of units, eg: CGS, SI, astronomical, ...
+	modetype::ModeType modetype = modetype::radial;    //the kind of modes to calculation: Cowling, 4th order, ...
+	std::vector<double> input_params {};//parameters needed for the stellar model calculation
+	std::string str_input_param {};  //a possible string parameter, such as a file name
+	std::size_t mode_num = 0;        //the number of modes to be calculated
+	std::size_t Ngrid = 0;           //the number of grid points to use in the calculation
+	std::set<int> l {};              //the set of L in calculation
+	std::map<int,std::set<int>> kl {};//for each L, the set of K to search
+	double mass = 0.0, radius = 0.0, zsurf = 0.0, logg = 0.0, teff = 0.0;//properties of a star
+	char params = 0;                 //records which of the above properties was specified
+	double adiabatic_index = 0.0;    //an adiabatic index to use in oscillations; if 0 uses natural Gamma
 };
 
 //an object specifying results for output from a calculation
 struct OutputData {
-	std::string calcname;			 //unique user-chosen identifier for calculation
-	regime::Regime regime;			 //the regime of physics to use: Newtonian, 1PN, GR
-	model::StellarModel model;		 //the model of star to use in calculations
-	units::Units units;				 //the choice of units, eg: CGS, SI, astronomical, ...
-	units::UnitSet unitset;			 //the base values to use in this unitset to convert back to SI
-	modetype::ModeType modetype;	 //the kind of modes to calculation: Cowling, 4th order, ...
+	std::string calcname {};		 //unique user-chosen identifier for calculation
+	regime::Regime regime = regime::PN0;          //the regime of physics to use: Newtonian, 1PN, GR
+	model::StellarModel model = model::polytrope; //the model of star to use in calculations
+	units::Units units = units::Units::astro;     //the choice of units, eg: CGS, SI, astronomical, ...
+	units::UnitSet unitset {};		 //the base values to use in this unitset to convert back to SI
+	modetype::ModeType modetype = modetype::radial;    //the kind of modes to calculation: Cowling, 4th order, ...
 	//
-	std::vector<double> input_params;//parameters needed for the stellar model calculation
-	std::string str_input_param;     //a possible string parameter, such as a file name
-	int mode_num, mode_writ, mode_done;//records the number of modes, which modes have been written
-	std::size_t Ngrid;				 //the number of grid points to use in the calculation
-	std::vector<int> l, k;           //vectors for L,K for each mode
-	std::vector<double> w, f, period;//vectors of frequency and period for each mode
-	std::vector<double> mode_SSR;    //the backsubstitution residual for each mode
-	int i_err;						 //a number of errors to calculate for each mode
+	std::vector<double> input_params {};//parameters needed for the stellar model calculation
+	std::string str_input_param {};  //a possible string parameter, such as a file name
+	int mode_num = 0, mode_writ = 0, mode_done = 0;//records the number of modes, which modes have been written
+	std::size_t Ngrid = 0;			 //the number of grid points to use in the calculation
+	std::vector<int> l {}, k {};     //vectors for L,K for each mode
+	std::vector<double> w {}, f {}, period {};//vectors of frequency and period for each mode
+	std::vector<double> mode_SSR {}; //the backsubstitution residual for each mode
+	int i_err = 0;					 //a number of errors to calculate for each mode
 	double **err = nullptr;					 //an array, for each mode listing all required errors
-	double mass, radius, zsurf, logg, teff, star_SSR;
-	double freq0;					 //a base frequency given the mass, radiusof star
-	double adiabatic_index;			 //an adiabatic index to use in oscillates; if 0 uses natural Gamma
-	char params;					 //records which of M,R,z,logg were specified
-	Star* star;						 //the stellar model
-	ModeDriver* driver;				 //the driver for the chosen mode type
-	std::vector<ModeBase*> mode;	 //an array of modes to be calculated
+	double mass = 0.0, radius = 0.0, zsurf = 0.0, logg = 0.0, teff = 0.0, star_SSR = 0.0;
+	double freq0 = 0.0;				 //a base frequency given the mass, radiusof star
+	double adiabatic_index = 0.0;	 //an adiabatic index to use in oscillates; if 0 uses natural Gamma
+	char params = 0;				 //records which of M,R,z,logg were specified
+	Star* star = nullptr;			 //the stellar model
+	ModeDriver* driver = nullptr;	 //the driver for the chosen mode type
+	std::vector<ModeBase*> mode {};	 //an array of modes to be calculated
 	// outout error flags -- these flags indicate which columns to print to estimate numerical error
 	bool error[error::numerror];
 	//the deconstructor

--- a/src/ThrainMode.hxx
+++ b/src/ThrainMode.hxx
@@ -89,7 +89,7 @@ int mode_finder(Calculation::OutputData &data){
 		std::map<int, MODE*> modefilled;
 
 		int ktry;
-		double w2try;
+		double w2try = 0.0;
 		MODE* modetry = nullptr;
 		
 // STEP 2:  perform first run with rough guesses 
@@ -152,7 +152,7 @@ int mode_finder(Calculation::OutputData &data){
 				mode::save_mode<MODE>(modetry, kfilled, w2filled, modefilled);
 				//if this is the one we want, continue to next mode
 				if(kfilled.count(ktarget)){
-					ThrainLogger::info("\tFOUND k=%d, w2=%lf\n", ktry,w2try);
+					ThrainLogger::info("\tFOUND k=%d, w2=%lf\n", ktry, modetry->getOmega2());
 					continue;
 				}
 // STEP 3c: if no min bracket, try to use current, or else use absolute min

--- a/tests/logger_test.cpp
+++ b/tests/logger_test.cpp
@@ -89,7 +89,7 @@ namespace {
 } // namespace
 
 struct SetUpTearDown {
-  ThrainLogger::LogLevel originalLevel;
+  ThrainLogger::LogLevel originalLevel = ThrainLogger::LogLevel::INFO;
   SetUpTearDown() { 
     originalLevel = ThrainLogger::getLogLevel();
     ThrainLogger::setLogLevel(ThrainLogger::LogLevel::INFO);

--- a/tests/matrix_test.cpp
+++ b/tests/matrix_test.cpp
@@ -91,8 +91,8 @@ bool matrix_triangular(T const (&m)[N][N]){
 struct Rngfixture {
     std::default_random_engine generator;
     std::uniform_real_distribution<double> distribution;
-    std::function<double(void)> rando;
-    std::function<std::complex<double>(void)> randoC;
+    std::function<double(void)> rando {};
+    std::function<std::complex<double>(void)> randoC {};
 
     explicit Rngfixture(unsigned seed = 0) : generator(seed), distribution(-10.0, 10.0) {
         rando = [this]()->double { return this->distribution(this->generator); };

--- a/tests/rootfind_test.cpp
+++ b/tests/rootfind_test.cpp
@@ -10,6 +10,9 @@ struct RootFindLineFixture {
     double root = 2.0;
     double over_root = 2.4;
     double under_root = 1.6;
+protected:
+    //never deleted through a base pointer
+    ~RootFindLineFixture() = default;
 };
 struct Line {
     virtual ~Line() = default;
@@ -33,6 +36,9 @@ struct RootFindParabola : RootFindLineFixture, Line {
 
 struct RootFind2DFixture {
     double xroot[2] = {1.5, 3.7};
+protected:
+    //never deleted through a base pointer
+    ~RootFind2DFixture() = default;
 };
 struct Field {
     virtual ~Field() = default;
@@ -643,6 +649,72 @@ TEST_CASE_FIXTURE(RootFind2DFixture, "rootfind: newton_search_2d") {
     rootfind::newton_search(downdown, xguess, dx, tol, 10);
     CHECK_DELTA( xguess[0], xroot[0], tol );
     CHECK_DELTA( xguess[1], xroot[1], tol );
+}
+
+TEST_CASE_FIXTURE(RootFindLineFixture, "newton_search_1d_flat") {
+    /** on a flat function the Newton step is 0/0; the search must
+    *   detect this and return finite values instead of NaN **/
+    double xguess = 1.0;
+    double const tol = 1.0e-10;
+    double const yfinal = rootfind::newton_search<double>(flat, xguess, 0.1, tol, 100);
+    CHECK( std::isfinite(xguess) );
+    CHECK( yfinal == 1.0 );
+    CHECK( xguess == 1.0 ); // no step can be taken on a flat function
+}
+
+TEST_CASE_FIXTURE(RootFind2DFixture, "newton_search_2d_target") {
+    // the target version forwards to the zero version; solution is x = xroot + target
+    double target[2] = {0.5, -0.5};
+    double xguess[2] = {3.*xroot[0], 5.*xroot[1]};
+    double dx[2] = {0.1, 0.2};
+    double const tol = 1.0e-10;
+
+    rootfind::newton_search<2>(upup, target, xguess, dx, tol, 10);
+    CHECK_DELTA( xguess[0], xroot[0] + target[0], tol );
+    CHECK_DELTA( xguess[1], xroot[1] + target[1], tol );
+}
+
+TEST_CASE("newton_search_2d_var_limit") {
+    /** a Newton step on log(x) from x=3 lands at x<0, where the function
+    *   is undefined; the var_limit must shrink the step to keep x positive **/
+    std::function<void(double[2], double[2])> const logfield =
+        [](double f[2], double x[2])->void {
+            f[0] = std::log(x[0]);
+            f[1] = x[1] - 1.0;
+        };
+    std::function<bool(double[2])> const positive =
+        [](double x[2])->bool { return x[0] > 0.0; };
+    double xguess[2] = {3.0, 1.0};
+    double dx[2] = {0.1, 0.1};
+    double const tol = 1.0e-10;
+
+    rootfind::newton_search<2>(logfield, xguess, dx, tol, 50, positive);
+    CHECK_DELTA( xguess[0], 1.0, tol );
+    CHECK_DELTA( xguess[1], 1.0, tol );
+}
+
+TEST_CASE("newton_search_2d_nan_recovery") {
+    /** the Jacobian probe at x[1] = 1.0 + 0.6 lands exactly on the NaN
+    *   region boundary, poisoning the Newton step with NaNs; the recovery
+    *   must fall back to a scaled previous step, which stays below the
+    *   boundary because pseudo_unif() < 1, after which the search converges **/
+    std::function<void(double[2], double[2])> const nanfield =
+        [](double f[2], double x[2])->void {
+            if(x[1] >= 1.6){
+                f[0] = f[1] = std::nan("");
+            }
+            else {
+                f[0] = x[0] - 2.0;
+                f[1] = x[1] - 1.0;
+            }
+        };
+    double xguess[2] = {3.0, 1.0};
+    double dx[2] = {0.1, 0.6};
+    double const tol = 1.0e-10;
+
+    rootfind::newton_search<2>(nanfield, xguess, dx, tol, 50);
+    CHECK_DELTA( xguess[0], 2.0, tol );
+    CHECK_DELTA( xguess[1], 1.0, tol );
 }
 
 } // end TEST_SUITE

--- a/tests/test_modes/DummyMode.h
+++ b/tests/test_modes/DummyMode.h
@@ -43,7 +43,7 @@ public:
     static int iter;
     static std::vector<int> klist;
 private:
-    int K;
+    int K = 0;
 };
 
 
@@ -63,7 +63,7 @@ public:
     static int iter;
     static std::vector<int> klist;
 private:
-    int K;
+    int K = 0;
 };
 
 

--- a/tests/test_modes/SineModeDriver.h
+++ b/tests/test_modes/SineModeDriver.h
@@ -28,8 +28,8 @@ public:
 	void getCoeff(double *CC, const std::size_t, const int, const double, const int) override;
 
 private:
-	std::size_t len;		//number of grid points for mode
-	std::size_t len_star;	//number of grid points in star
+	std::size_t len = 0;		//number of grid points for mode
+	std::size_t len_star = 0;	//number of grid points in star
 	enum VarNames {sin=0, cos};
 
 	double x(std::size_t const, int const);

--- a/tests/thrainconfig_test.cpp
+++ b/tests/thrainconfig_test.cpp
@@ -17,7 +17,7 @@ namespace {
     ~SetupTeardown() {
       ThrainConfig::reconfigure(original_config);
     }
-    std::unordered_map<std::string, std::string> original_config;
+    std::unordered_map<std::string, std::string> original_config {};
   };
 }
 


### PR DESCRIPTION
THRAIN is my dissertation code.  I made it while a graduate student at UNC, and it wa entirely developed using an Intel Mac running GCC.  I had multiple warning flags turned on, and THRAIN always built locally without compiler error or warning.

When I setup the automatic GitHub CI/CD, I discovered there were hundreds of errors when building on other systems (including when building on Mac with clang).

This has been a long standing nuisance, especially when trying to debug errors on systems, where the unit tests are littered with warning statements.

The purpose of this PR is to clear out the compiler warnings.

Check compilers.  There should be **no** compiler warnings.
- [x] ubuntu gcc clear
- [x] ubuntu gcc9 clear
- [x] macos gcc clear
- [x] macos clang clear
- [x] windows gcc clear

From now on, compile warnings on any system will be treated as an error, to prevent further warnings from building up.